### PR TITLE
Add some Proto3 support

### DIFF
--- a/protorust_codegen/src/main.rs
+++ b/protorust_codegen/src/main.rs
@@ -35,15 +35,12 @@ fn main() {
     let mut data = Vec::with_capacity(in_file.metadata()
                                      .expect("Cannot get input file length")
                                      .len() as usize);
-    let mut parsed_file = {
+    let parsed_file = {
         let f = File::open(&in_file).expect(&usage);
         let mut reader = BufReader::new(f);
         reader.read_to_end(&mut data).expect("Cannot read input file");
         FileDescriptor::from_bytes(&data).expect("Cannot parse protobuf messages")
     };
-
-
-    parsed_file.break_cycles();
 
     let name = in_file.file_name().and_then(|e| e.to_str()).unwrap();
     let mut w = BufWriter::new(File::create(out_file).expect("Cannot create output file"));

--- a/protorust_codegen/src/parser.rs
+++ b/protorust_codegen/src/parser.rs
@@ -36,7 +36,7 @@ named!(frequency<Frequency>,
             tag!("required") => { |_| Frequency::Required } ));
 
 named!(message_field<Field>, do_parse!(
-    frequency: frequency >> many1!(br) >>
+    frequency: opt!(frequency) >> many1!(br) >>
     typ: word >> many1!(br) >>
     name: word >> many0!(br) >>
     tag!("=") >> many0!(br) >>
@@ -45,11 +45,11 @@ named!(message_field<Field>, do_parse!(
     packed: opt!(packed) >> many0!(br) >> tag!(";") >> many0!(br) >>
     (Field {
        name: name,
-       frequency: frequency,
+       frequency: frequency.unwrap_or(Frequency::Optional),
        typ: typ,
        number: number,
        default: default,
-       packed: packed.unwrap_or(false),
+       packed: packed,
        boxed: false,
     })));
 

--- a/protorust_codegen/src/parser.rs
+++ b/protorust_codegen/src/parser.rs
@@ -1,5 +1,5 @@
 use std::str;
-use types::{Frequency, Field, Message, Enumerator, MessageOrEnum, FileDescriptor};
+use types::{Frequency, Field, Message, Enumerator, MessageOrEnum, FileDescriptor, Syntax};
 use nom::{multispace, digit};
 
 fn is_word(b: u8) -> bool {
@@ -15,6 +15,10 @@ named!(comment<()>, do_parse!(tag!("//") >> take_until_and_consume!("\n") >> ())
 
 /// word break: multispace or comment
 named!(br<()>, alt!(map!(multispace, |_| ()) | comment));
+
+named!(syntax<Syntax>, do_parse!(tag!("syntax") >> many0!(br) >> tag!("=") >>
+    proto: alt!(tag!("\"proto2\"") => { |_| Syntax::Proto2 } |
+                tag!("\"proto3\"") => { |_| Syntax::Proto3 }) >> (proto)));
 
 named!(default_value<&str>, do_parse!(
     tag!("[") >> many0!(br) >> tag!("default") >> many0!(br) >> tag!("=") >> many0!(br) >> 
@@ -82,9 +86,10 @@ named!(message_or_enum<MessageOrEnum>, alt!(
          ignore => { |_| MessageOrEnum::Ignore } ));
 
 named!(pub file_descriptor<FileDescriptor>, do_parse!(
-    many0!(br) >>
+    many0!(br) >> syntax: opt!(syntax) >> many0!(br) >>
     message_and_enums: many0!(message_or_enum) >>
     (FileDescriptor {
+        syntax: syntax.unwrap_or(Syntax::Proto2),
         message_and_enums: message_and_enums,
         messages: Vec::new(),
         enums: Vec::new(),

--- a/protorust_codegen/src/types.rs
+++ b/protorust_codegen/src/types.rs
@@ -389,7 +389,14 @@ pub enum MessageOrEnum<'a> {
 }
 
 #[derive(Debug)]
+pub enum Syntax {
+    Proto2,
+    Proto3,
+}
+
+#[derive(Debug)]
 pub struct FileDescriptor<'a> {
+    pub syntax: Syntax,
     pub message_and_enums: Vec<MessageOrEnum<'a>>,
     pub messages: Vec<Message<'a>>,
     pub enums: Vec<Enumerator<'a>>,


### PR DESCRIPTION
Probably partially as a start ...

- add syntax parsing
    - set all repeated fields as packed per default if proto3
    - default all non defaulted numeric to 0
- do not use `Option<T>` when a field has a default, instead use that default in place of `None`
  and do not write the field when it is equal to the default value