### PR TITLE
Avoid buffering when writing to Vec

### DIFF
--- a/benches/rust-protobuf/perftest.rs
+++ b/benches/rust-protobuf/perftest.rs
@@ -52,7 +52,7 @@ impl TestRunner {
         let mut buf = Vec::new();
         a[0] = measure(random_data.len() as u64, || {
             for m in &random_data {
-                m.write_length_delimited_to_writer(&mut buf).unwrap();
+                m.write_length_delimited_to_vec(&mut buf).unwrap();
             }
         }).0;
 


### PR DESCRIPTION
Could you please also rerun your benchmark, so the different won't be so horrible? (I've fixed a couple of bottlenecks).