### PR TITLE
add examples/codegen_example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: rust
 rust:
     - stable
-    - beta
+    - nightly

--- a/README.md
+++ b/README.md
@@ -73,9 +73,15 @@ fn main() {
 }
 ```
 
+## Examples directory
+
+You can find basic examples in the [examples](examples) directory.
+- [codegen_example](examples/codegen_example.rs): A basic write/read loop on all datatypes
+
 ## Message <-> struct
 
 #### Proto definition
+
 ```
 enum FooEnum {
     FIRST_VALUE = 1;

--- a/examples/codegen/generate_module.sh
+++ b/examples/codegen/generate_module.sh
@@ -1,0 +1,3 @@
+cd ../../codegen
+cargo run ../examples/codegen/data_types.proto
+cd ../examples/codegen

--- a/examples/codegen/mod.rs
+++ b/examples/codegen/mod.rs
@@ -1,3 +1,3 @@
 //! Simple module to etract codegen from actual examples
 
-pub mod data_type;
+pub mod data_types;

--- a/examples/codegen_example.rs
+++ b/examples/codegen_example.rs
@@ -1,0 +1,44 @@
+extern crate quick_protobuf;
+
+mod codegen;
+
+use std::borrow::Cow;
+
+use codegen::data_types::FooMessage;
+use quick_protobuf::{BytesReader, Writer};
+
+fn main() {
+
+    // Generate a message, somehow
+    //
+    // For the example we will leverage the `Default` derive of all messages
+    let message = FooMessage {
+        f_int32: Some(54), 
+        f_string: Some(Cow::Borrowed("Hello world from example!")),
+        f_bytes: Some(Cow::Borrowed(b"I see you!")),
+        ..FooMessage::default()
+    };
+
+    // Write the message into our buffer, it could be a file, a ZipFile etc ...
+    let mut out = Vec::new();
+    {
+        let mut writer = Writer::new(&mut out);
+        writer.write_message(&message).expect("Cannot write message!");
+    }
+    println!("Message written successfully!");
+
+    // Try to read it back and confirm that we still have the exact same message
+    //
+    // In general, if we had written the data to say, a file, or if someone else have written that
+    // data, it would be more convenient to use a `Reader` which will feed an internal, owned, buffer
+    // Here, on the contrary, we already hold the `out` buffer. Thus it is more efficient 
+    // to directly use a `BytesWriter`. 
+    let read_message = {
+        let mut reader = BytesReader::from_bytes(&out);
+        reader.read_message(&out, FooMessage::from_reader).expect("Cannot read message")
+    };
+    assert_eq!(message, read_message);
+
+    println!("Message read back and everything matches!");
+    println!("{:#?}", read_message);
+}


### PR DESCRIPTION
Closes #13 

This adds a basic example 
- a generated module (there is a script in the same folder to show how to generate it)
- create a message object
- serialize it into a buffer
- read it back and confirm it is the same
- print it

This also fixes some warning on codegen