### PR TITLE
Support Oneofs

### DIFF
--- a/codegen/run_test.sh
+++ b/codegen/run_test.sh
@@ -1,0 +1,4 @@
+cargo run ../examples/codegen/data_types_import.proto
+cargo run ../examples/codegen/data_types.proto
+cd ..
+cargo run --example codegen_example

--- a/examples/codegen/data_types.proto
+++ b/examples/codegen/data_types.proto
@@ -35,6 +35,11 @@ message FooMessage {
     optional BazMessage.Nested f_nested = 23;
     optional BazMessage.Nested.NestedEnum f_nested_enum = 24;
     map<string, int32> f_map = 25;
+    oneof test_oneof {
+        int32 f1 = 26;
+        bool f2 = 27;
+        string f3 = 28;
+    }
 }
 
 message BazMessage {

--- a/examples/codegen_example.rs
+++ b/examples/codegen_example.rs
@@ -4,7 +4,7 @@ mod codegen;
 
 use std::borrow::Cow;
 
-use codegen::data_types::{self, FooMessage};
+use codegen::data_types::{self, FooMessage, OneOftest_oneof};
 
 // Imported fields contain package a.b, which is translated into
 // mod_a::mod_b rust module
@@ -41,6 +41,9 @@ fn main() {
 
         // a map!
         f_map: vec![(Cow::Borrowed("foo"), 1), (Cow::Borrowed("bar"), 2)].into_iter().collect(),
+
+        // a oneof value
+        test_oneof: OneOftest_oneof::f1(2),
 
         // Each message implements Default ... which makes it much easier
         ..FooMessage::default()


### PR DESCRIPTION
```
message A {
    oneof f_choice {
        int32 choice1 = 1;
        int64 choice2 = 2;
        string choice3 = 3;
    }
}
```
```rust
pub enum OneOff_choice<'a> {
    choice1(i32),
    choice2(i64),
    choice3(Cow<'a, str>),
    None
}

impl<'a> Default for OneOff_choice {
    OneOff_choice::None
}

pub struct A {
    f_choice: OneOff_choice<'a>,
}
```
