### PR TITLE
Enhance fixed size packed fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,21 @@ It provides both:
   - each `.proto` file will generate a minimal rust module (one function to read, one to write, and one to compute the size of the messages)
   - each message will generate a rust struct where:
 
-    | **Proto**      | **Rust**                |
-    |----------------|-------------------------|
-    | bytes          | `Cow<'a, [u8]>`         |
-    | string         | `Cow<'a, str>`          |
-    | other scalars  | rust primitive          |
-    | repeated       | `Vec`                   |
-    | optional       | `Option`                |
-    | message        | `struct`                |
-    | enum           | `enum`                  |
-    | map            | `HashMap`               |
-    | oneof Name     | `OneOfName` enum        |
-    | nested `m1`    | `mod_m1` module         |
-    | package `a.b`  | `mod_a::mod_b` modules  |
-    | import file_a.proto | `use super::file_a::*` |
+    | **Proto**                    | **Rust**                |
+    |------------------------------|-------------------------|
+    | bytes                        | `Cow<'a, [u8]>`         |
+    | string                       | `Cow<'a, str>`          |
+    | other scalars                | rust primitive          |
+    | repeated                     | `Vec`                   |
+    | repeated, packed, fixed size | `Cow<'a, [M]>`          |
+    | optional                     | `Option`                |
+    | message                      | `struct`                |
+    | enum                         | `enum`                  |
+    | map                          | `HashMap`               |
+    | oneof Name                   | `OneOfName` enum        |
+    | nested `m1`                  | `mod_m1` module         |
+    | package `a.b`                | `mod_a::mod_b` modules  |
+    | import file_a.proto          | `use super::file_a::*` |
 
   - no need to use google `protoc` tool to generate the modules
 - **quick-protobuf**, a protobuf file parser: 

--- a/benches/perftest.rs
+++ b/benches/perftest.rs
@@ -78,8 +78,8 @@ fn generate_repeated_packed_int32() -> Vec<TestRepeatedPackedInt32> {
 
 perfbench!(generate_repeated_packed_int32, TestRepeatedPackedInt32, write_repeated_packed_int32, read_repeated_packed_int32);
 
-fn generate_repeated_packed_float() -> Vec<TestRepeatedPackedFloat> {
-    (1..40).map(|j| TestRepeatedPackedFloat { values: (0..100).map(|i| (i * j) as f32).collect() })
+fn generate_repeated_packed_float() -> Vec<TestRepeatedPackedFloat<'static>> {
+    (1..40).map(|j| TestRepeatedPackedFloat { values: Cow::Owned((0..100).map(|i| (i * j) as f32).collect()) })
         .collect()
 }
 

--- a/benches/perftest.rs
+++ b/benches/perftest.rs
@@ -78,6 +78,13 @@ fn generate_repeated_packed_int32() -> Vec<TestRepeatedPackedInt32> {
 
 perfbench!(generate_repeated_packed_int32, TestRepeatedPackedInt32, write_repeated_packed_int32, read_repeated_packed_int32);
 
+fn generate_repeated_packed_float() -> Vec<TestRepeatedPackedFloat> {
+    (1..40).map(|j| TestRepeatedPackedFloat { values: (0..100).map(|i| (i * j) as f32).collect() })
+        .collect()
+}
+
+perfbench!(generate_repeated_packed_float, TestRepeatedPackedFloat, write_repeated_packed_float, read_repeated_packed_float);
+
 fn generate_repeated_messages() -> Vec<TestRepeatedMessages> {
     let mut messages = Vec::new();
     messages.push(TestRepeatedMessages {
@@ -86,7 +93,7 @@ fn generate_repeated_messages() -> Vec<TestRepeatedMessages> {
         messages3: vec![],
     });
 
-    for _ in 0..10 {
+    for _ in 0..5 {
         let i1 = min(messages.len() % 3, messages.len() - 1);
         let i2 = min(messages.len() % 6, messages.len() - 1);
         let i3 = min(messages.len() % 9, messages.len() - 1);
@@ -179,6 +186,7 @@ fn generate_all() -> Vec<PerftestData<'static>> {
         test_optional_messages: generate_optional_messages(),
         test_strings: generate_strings(),
         test_repeated_packed_int32: generate_repeated_packed_int32(),
+        test_repeated_packed_float: generate_repeated_packed_float(),
         test_small_bytearrays: generate_small_bytes(),
         test_large_bytearrays: generate_large_bytes(),
         test_map: generate_map(),

--- a/benches/perftest_data/mod.rs
+++ b/benches/perftest_data/mod.rs
@@ -125,7 +125,7 @@ impl<'a> MessageWrite for TestRepeatedPackedFloat<'a> {
     }
 
     fn write_message<W: Write>(&self, w: &mut Writer<W>) -> Result<()> {
-        w.write_packed_with_tag(10, &self.values, |w, m| w.write_float(*m), &|_| 4)?;
+        w.write_packed_fixed_with_tag(10, &self.values)?;
         Ok(())
     }
 }

--- a/benches/perftest_data/mod.rs
+++ b/benches/perftest_data/mod.rs
@@ -125,7 +125,7 @@ impl MessageWrite for TestRepeatedPackedFloat {
     }
 
     fn write_message<W: Write>(&self, w: &mut Writer<W>) -> Result<()> {
-        w.write_packed_with_tag(10, &self.values, |w, m| w.write_float(*m), &|m| 4)?;
+        w.write_packed_with_tag(10, &self.values, |w, m| w.write_float(*m), &|_| 4)?;
         Ok(())
     }
 }

--- a/benches/perftest_data/mod.rs
+++ b/benches/perftest_data/mod.rs
@@ -31,7 +31,7 @@ impl Test1 {
 
 impl MessageWrite for Test1 {
     fn get_size(&self) -> usize {
-        self.value.as_ref().map_or(0, |m| 1 + sizeof_varint(*m as u64))
+        self.value.as_ref().map_or(0, |m| 1 + sizeof_varint(*(m) as u64))
     }
 
     fn write_message<W: Write>(&self, w: &mut Writer<W>) -> Result<()> {
@@ -61,7 +61,7 @@ impl TestRepeatedBool {
 
 impl MessageWrite for TestRepeatedBool {
     fn get_size(&self) -> usize {
-        self.values.iter().map(|s| 1 + sizeof_varint(*s as u64)).sum::<usize>()
+        self.values.iter().map(|s| 1 + sizeof_varint(*(s) as u64)).sum::<usize>()
     }
 
     fn write_message<W: Write>(&self, w: &mut Writer<W>) -> Result<()> {
@@ -91,11 +91,41 @@ impl TestRepeatedPackedInt32 {
 
 impl MessageWrite for TestRepeatedPackedInt32 {
     fn get_size(&self) -> usize {
-        if self.values.is_empty() { 0 } else { 1 + sizeof_len(self.values.iter().map(|s| sizeof_varint(*s as u64)).sum::<usize>()) }
+        if self.values.is_empty() { 0 } else { 1 + sizeof_len(self.values.iter().map(|s| sizeof_varint(*(s) as u64)).sum::<usize>()) }
     }
 
     fn write_message<W: Write>(&self, w: &mut Writer<W>) -> Result<()> {
-        w.write_packed_with_tag(10, &self.values, |w, m| w.write_int32(*m), &|m| sizeof_varint(*m as u64))?;
+        w.write_packed_with_tag(10, &self.values, |w, m| w.write_int32(*m), &|m| sizeof_varint(*(m) as u64))?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Clone)]
+pub struct TestRepeatedPackedFloat {
+    pub values: Vec<f32>,
+}
+
+impl TestRepeatedPackedFloat {
+    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+        let mut msg = Self::default();
+        while !r.is_eof() {
+            match r.next_tag(bytes) {
+                Ok(10) => msg.values = r.read_packed(bytes, |r, bytes| r.read_float(bytes))?,
+                Ok(t) => { r.read_unknown(bytes, t)?; }
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(msg)
+    }
+}
+
+impl MessageWrite for TestRepeatedPackedFloat {
+    fn get_size(&self) -> usize {
+        if self.values.is_empty() { 0 } else { 1 + sizeof_len(self.values.len() * 4) }
+    }
+
+    fn write_message<W: Write>(&self, w: &mut Writer<W>) -> Result<()> {
+        w.write_packed_with_tag(10, &self.values, |w, m| w.write_float(*m), &|m| 4)?;
         Ok(())
     }
 }
@@ -125,9 +155,9 @@ impl TestRepeatedMessages {
 
 impl MessageWrite for TestRepeatedMessages {
     fn get_size(&self) -> usize {
-        self.messages1.iter().map(|s| 1 + sizeof_len(s.get_size())).sum::<usize>()
-        + self.messages2.iter().map(|s| 1 + sizeof_len(s.get_size())).sum::<usize>()
-        + self.messages3.iter().map(|s| 1 + sizeof_len(s.get_size())).sum::<usize>()
+        self.messages1.iter().map(|s| 1 + sizeof_len((s).get_size())).sum::<usize>()
+        + self.messages2.iter().map(|s| 1 + sizeof_len((s).get_size())).sum::<usize>()
+        + self.messages3.iter().map(|s| 1 + sizeof_len((s).get_size())).sum::<usize>()
     }
 
     fn write_message<W: Write>(&self, w: &mut Writer<W>) -> Result<()> {
@@ -163,9 +193,9 @@ impl TestOptionalMessages {
 
 impl MessageWrite for TestOptionalMessages {
     fn get_size(&self) -> usize {
-        self.message1.as_ref().map_or(0, |m| 1 + sizeof_len(m.get_size()))
-        + self.message2.as_ref().map_or(0, |m| 1 + sizeof_len(m.get_size()))
-        + self.message3.as_ref().map_or(0, |m| 1 + sizeof_len(m.get_size()))
+        self.message1.as_ref().map_or(0, |m| 1 + sizeof_len((m).get_size()))
+        + self.message2.as_ref().map_or(0, |m| 1 + sizeof_len((m).get_size()))
+        + self.message3.as_ref().map_or(0, |m| 1 + sizeof_len((m).get_size()))
     }
 
     fn write_message<W: Write>(&self, w: &mut Writer<W>) -> Result<()> {
@@ -201,9 +231,9 @@ impl<'a> TestStrings<'a> {
 
 impl<'a> MessageWrite for TestStrings<'a> {
     fn get_size(&self) -> usize {
-        self.s1.as_ref().map_or(0, |m| 1 + sizeof_len(m.len()))
-        + self.s2.as_ref().map_or(0, |m| 1 + sizeof_len(m.len()))
-        + self.s3.as_ref().map_or(0, |m| 1 + sizeof_len(m.len()))
+        self.s1.as_ref().map_or(0, |m| 1 + sizeof_len((m).len()))
+        + self.s2.as_ref().map_or(0, |m| 1 + sizeof_len((m).len()))
+        + self.s3.as_ref().map_or(0, |m| 1 + sizeof_len((m).len()))
     }
 
     fn write_message<W: Write>(&self, w: &mut Writer<W>) -> Result<()> {
@@ -235,7 +265,7 @@ impl<'a> TestBytes<'a> {
 
 impl<'a> MessageWrite for TestBytes<'a> {
     fn get_size(&self) -> usize {
-        self.b1.as_ref().map_or(0, |m| 1 + sizeof_len(m.len()))
+        self.b1.as_ref().map_or(0, |m| 1 + sizeof_len((m).len()))
     }
 
     fn write_message<W: Write>(&self, w: &mut Writer<W>) -> Result<()> {
@@ -268,11 +298,11 @@ impl<'a> TestMap<'a> {
 
 impl<'a> MessageWrite for TestMap<'a> {
     fn get_size(&self) -> usize {
-        self.value.iter().map(|(k, v)| 1 + sizeof_len(2 + sizeof_len(k.len()) + sizeof_varint(*v as u64))).sum::<usize>()
+        self.value.iter().map(|(k, v)| 1 + sizeof_len(2 + sizeof_len((k).len()) + sizeof_varint(*(v) as u64))).sum::<usize>()
     }
 
     fn write_message<W: Write>(&self, w: &mut Writer<W>) -> Result<()> {
-        for (k, v) in self.value.iter() { w.write_with_tag(10, |w| w.write_map(2 + sizeof_len(k.len()) + sizeof_varint(*v as u64), 10, |w| w.write_string(&**k), 16, |w| w.write_uint32(*v)))?; }
+        for (k, v) in self.value.iter() { w.write_with_tag(10, |w| w.write_map(2 + sizeof_len((k).len()) + sizeof_varint(*(v) as u64), 10, |w| w.write_string(&**k), 16, |w| w.write_uint32(*v)))?; }
         Ok(())
     }
 }
@@ -285,6 +315,7 @@ pub struct PerftestData<'a> {
     pub test_optional_messages: Vec<TestOptionalMessages>,
     pub test_strings: Vec<TestStrings<'a>>,
     pub test_repeated_packed_int32: Vec<TestRepeatedPackedInt32>,
+    pub test_repeated_packed_float: Vec<TestRepeatedPackedFloat>,
     pub test_small_bytearrays: Vec<TestBytes<'a>>,
     pub test_large_bytearrays: Vec<TestBytes<'a>>,
     pub test_map: Vec<TestMap<'a>>,
@@ -301,9 +332,10 @@ impl<'a> PerftestData<'a> {
                 Ok(34) => msg.test_optional_messages.push(r.read_message(bytes, TestOptionalMessages::from_reader)?),
                 Ok(42) => msg.test_strings.push(r.read_message(bytes, TestStrings::from_reader)?),
                 Ok(50) => msg.test_repeated_packed_int32.push(r.read_message(bytes, TestRepeatedPackedInt32::from_reader)?),
-                Ok(58) => msg.test_small_bytearrays.push(r.read_message(bytes, TestBytes::from_reader)?),
-                Ok(66) => msg.test_large_bytearrays.push(r.read_message(bytes, TestBytes::from_reader)?),
-                Ok(74) => msg.test_map.push(r.read_message(bytes, TestMap::from_reader)?),
+                Ok(58) => msg.test_repeated_packed_float.push(r.read_message(bytes, TestRepeatedPackedFloat::from_reader)?),
+                Ok(66) => msg.test_small_bytearrays.push(r.read_message(bytes, TestBytes::from_reader)?),
+                Ok(74) => msg.test_large_bytearrays.push(r.read_message(bytes, TestBytes::from_reader)?),
+                Ok(82) => msg.test_map.push(r.read_message(bytes, TestMap::from_reader)?),
                 Ok(t) => { r.read_unknown(bytes, t)?; }
                 Err(e) => return Err(e),
             }
@@ -314,15 +346,16 @@ impl<'a> PerftestData<'a> {
 
 impl<'a> MessageWrite for PerftestData<'a> {
     fn get_size(&self) -> usize {
-        self.test1.iter().map(|s| 1 + sizeof_len(s.get_size())).sum::<usize>()
-        + self.test_repeated_bool.iter().map(|s| 1 + sizeof_len(s.get_size())).sum::<usize>()
-        + self.test_repeated_messages.iter().map(|s| 1 + sizeof_len(s.get_size())).sum::<usize>()
-        + self.test_optional_messages.iter().map(|s| 1 + sizeof_len(s.get_size())).sum::<usize>()
-        + self.test_strings.iter().map(|s| 1 + sizeof_len(s.get_size())).sum::<usize>()
-        + self.test_repeated_packed_int32.iter().map(|s| 1 + sizeof_len(s.get_size())).sum::<usize>()
-        + self.test_small_bytearrays.iter().map(|s| 1 + sizeof_len(s.get_size())).sum::<usize>()
-        + self.test_large_bytearrays.iter().map(|s| 1 + sizeof_len(s.get_size())).sum::<usize>()
-        + self.test_map.iter().map(|s| 1 + sizeof_len(s.get_size())).sum::<usize>()
+        self.test1.iter().map(|s| 1 + sizeof_len((s).get_size())).sum::<usize>()
+        + self.test_repeated_bool.iter().map(|s| 1 + sizeof_len((s).get_size())).sum::<usize>()
+        + self.test_repeated_messages.iter().map(|s| 1 + sizeof_len((s).get_size())).sum::<usize>()
+        + self.test_optional_messages.iter().map(|s| 1 + sizeof_len((s).get_size())).sum::<usize>()
+        + self.test_strings.iter().map(|s| 1 + sizeof_len((s).get_size())).sum::<usize>()
+        + self.test_repeated_packed_int32.iter().map(|s| 1 + sizeof_len((s).get_size())).sum::<usize>()
+        + self.test_repeated_packed_float.iter().map(|s| 1 + sizeof_len((s).get_size())).sum::<usize>()
+        + self.test_small_bytearrays.iter().map(|s| 1 + sizeof_len((s).get_size())).sum::<usize>()
+        + self.test_large_bytearrays.iter().map(|s| 1 + sizeof_len((s).get_size())).sum::<usize>()
+        + self.test_map.iter().map(|s| 1 + sizeof_len((s).get_size())).sum::<usize>()
     }
 
     fn write_message<W: Write>(&self, w: &mut Writer<W>) -> Result<()> {
@@ -332,9 +365,10 @@ impl<'a> MessageWrite for PerftestData<'a> {
         for s in &self.test_optional_messages { w.write_with_tag(34, |w| w.write_message(s))?; }
         for s in &self.test_strings { w.write_with_tag(42, |w| w.write_message(s))?; }
         for s in &self.test_repeated_packed_int32 { w.write_with_tag(50, |w| w.write_message(s))?; }
-        for s in &self.test_small_bytearrays { w.write_with_tag(58, |w| w.write_message(s))?; }
-        for s in &self.test_large_bytearrays { w.write_with_tag(66, |w| w.write_message(s))?; }
-        for s in &self.test_map { w.write_with_tag(74, |w| w.write_message(s))?; }
+        for s in &self.test_repeated_packed_float { w.write_with_tag(58, |w| w.write_message(s))?; }
+        for s in &self.test_small_bytearrays { w.write_with_tag(66, |w| w.write_message(s))?; }
+        for s in &self.test_large_bytearrays { w.write_with_tag(74, |w| w.write_message(s))?; }
+        for s in &self.test_map { w.write_with_tag(82, |w| w.write_message(s))?; }
         Ok(())
     }
 }

--- a/benches/perftest_data/perftest_data.proto
+++ b/benches/perftest_data/perftest_data.proto
@@ -10,6 +10,10 @@ message TestRepeatedPackedInt32 {
     repeated int32 values = 1 [ packed = true ];
 }
 
+message TestRepeatedPackedFloat {
+    repeated float values = 1 [ packed = true ];
+}
+
 message TestRepeatedMessages {
     repeated TestRepeatedMessages messages1 = 1;
     repeated TestRepeatedMessages messages2 = 2;
@@ -43,7 +47,8 @@ message PerftestData {
     repeated TestOptionalMessages test_optional_messages = 4;
     repeated TestStrings test_strings = 5;
     repeated TestRepeatedPackedInt32 test_repeated_packed_int32 = 6;
-    repeated TestBytes test_small_bytearrays = 7;
-    repeated TestBytes test_large_bytearrays = 8;
-    repeated TestMap test_map = 9;
+    repeated TestRepeatedPackedFloat test_repeated_packed_float = 7;
+    repeated TestBytes test_small_bytearrays = 8;
+    repeated TestBytes test_large_bytearrays = 9;
+    repeated TestMap test_map = 10;
 }

--- a/codegen/src/types.rs
+++ b/codegen/src/types.rs
@@ -465,8 +465,9 @@ impl Field {
                 }
             },
             Frequency::Repeated if self.packed() => {
-                writeln!(w, "        w.write_packed_with_tag({}, &self.{}, |w, m| w.{}, &|m| {})?;",
-                         self.tag(), self.name, self.typ.get_write("m", self.boxed), self.typ.get_size("m"))?
+                let (m, v) = if !self.typ.is_fixed_size() { ("m", "m") } else { ("", "_") };
+                writeln!(w, "        w.write_packed_with_tag({}, &self.{}, |w, m| w.{}, &|{}| {})?;",
+                         self.tag(), self.name, self.typ.get_write("m", self.boxed), v, self.typ.get_size(m))?
             }
             Frequency::Repeated => {
                 writeln!(w, "        for s in &self.{} {{ w.write_with_tag({}, |w| w.{})?; }}", 

--- a/codegen/src/types.rs
+++ b/codegen/src/types.rs
@@ -472,10 +472,12 @@ impl Field {
                              self.name, d, self.tag(), self.typ.get_write(&format!("&self.{}", self.name), self.boxed))?;
                 }
             },
+            Frequency::Repeated if self.packed() && self.typ.is_fixed_size() => {
+                writeln!(w, "        w.write_packed_fixed_with_tag({}, &self.{})?;", self.tag(), self.name)?
+            }
             Frequency::Repeated if self.packed() => {
-                let (m, v) = if !self.typ.is_fixed_size() { ("m", "m") } else { ("", "_") };
-                writeln!(w, "        w.write_packed_with_tag({}, &self.{}, |w, m| w.{}, &|{}| {})?;",
-                         self.tag(), self.name, self.typ.get_write("m", self.boxed), v, self.typ.get_size(m))?
+                writeln!(w, "        w.write_packed_with_tag({}, &self.{}, |w, m| w.{}, &|m| {})?;",
+                         self.tag(), self.name, self.typ.get_write("m", self.boxed), self.typ.get_size("m"))?
             }
             Frequency::Repeated => {
                 writeln!(w, "        for s in &self.{} {{ w.write_with_tag({}, |w| w.{})?; }}", 

--- a/examples/codegen/data_types.proto
+++ b/examples/codegen/data_types.proto
@@ -30,15 +30,16 @@ message FooMessage {
     optional BarMessage f_bar_message = 18;
     repeated int32 f_repeated_int32 = 19;
     repeated int32 f_repeated_packed_int32 = 20 [ packed = true ];
-    optional a.b.ImportedMessage f_imported = 21;
-    optional BazMessage f_baz = 22;
-    optional BazMessage.Nested f_nested = 23;
-    optional BazMessage.Nested.NestedEnum f_nested_enum = 24;
-    map<string, int32> f_map = 25;
+    repeated float f_repeated_packed_float = 21 [ packed = true ];
+    optional a.b.ImportedMessage f_imported = 22;
+    optional BazMessage f_baz = 23;
+    optional BazMessage.Nested f_nested = 24;
+    optional BazMessage.Nested.NestedEnum f_nested_enum = 25;
+    map<string, int32> f_map = 26;
     oneof test_oneof {
-        int32 f1 = 26;
-        bool f2 = 27;
-        string f3 = 28;
+        int32 f1 = 27;
+        bool f2 = 28;
+        string f3 = 29;
     }
 }
 

--- a/examples/codegen/data_types.rs
+++ b/examples/codegen/data_types.rs
@@ -209,7 +209,7 @@ impl<'a> MessageWrite for FooMessage<'a> {
         if let Some(ref s) = self.f_bar_message { w.write_with_tag(146, |w| w.write_message(s))?; }
         for s in &self.f_repeated_int32 { w.write_with_tag(152, |w| w.write_int32(*s))?; }
         w.write_packed_with_tag(162, &self.f_repeated_packed_int32, |w, m| w.write_int32(*m), &|m| sizeof_varint(*(m) as u64))?;
-        w.write_packed_with_tag(170, &self.f_repeated_packed_float, |w, m| w.write_float(*m), &|_| 4)?;
+        w.write_packed_fixed_with_tag(170, &self.f_repeated_packed_float)?;
         if let Some(ref s) = self.f_imported { w.write_with_tag(178, |w| w.write_message(s))?; }
         if let Some(ref s) = self.f_baz { w.write_with_tag(186, |w| w.write_message(s))?; }
         if let Some(ref s) = self.f_nested { w.write_with_tag(194, |w| w.write_message(s))?; }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -179,9 +179,9 @@ impl<W: Write> Writer<W> {
     /// `item_size` is internally used to compute the total length
     /// As the length is fixed (and the same as rust internal representation, we can directly dump
     /// all data at once
-    pub fn write_packed_fixed_size<M>(&mut self, v: &[M]) -> Result<()> {
+    pub fn write_packed_fixed<M>(&mut self, v: &[M]) -> Result<()> {
         let len = v.len() * ::std::mem::size_of::<M>();
-        let bytes = unsafe { ::std::slice::from_raw_parts(v as *const [M] as *const M as *const u8, len) };
+        let bytes = unsafe { ::std::slice::from_raw_parts(v.as_ptr() as *const u8, len) };
         self.write_bytes(bytes)
     }
 
@@ -235,10 +235,8 @@ impl<W: Write> Writer<W> {
 
         self.write_tag(tag)?;
         let len = ::std::mem::size_of::<M>() * v.len();
-        self.write_varint(len as u64)?;
         let bytes = unsafe { ::std::slice::from_raw_parts(v.as_ptr() as *const u8, len) };
-        self.inner.write_all(bytes)?;
-        Ok(())
+        self.write_bytes(bytes)
     }
 
     /// Writes tag then repeated field with fixed length item size

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -224,6 +224,23 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
+    /// Writes tag then repeated field
+    ///
+    /// If array is empty, then do nothing (do not even write the tag)
+    pub fn write_packed_fixed_with_tag<M>(&mut self, tag: u32, v: &[M]) -> Result<()>
+    {
+        if v.is_empty() {
+            return Ok(());
+        }
+
+        self.write_tag(tag)?;
+        let len = ::std::mem::size_of::<M>() * v.len();
+        self.write_varint(len as u64)?;
+        let bytes = unsafe { ::std::slice::from_raw_parts(v.as_ptr() as *const u8, len) };
+        self.inner.write_all(bytes)?;
+        Ok(())
+    }
+
     /// Writes tag then repeated field with fixed length item size
     ///
     /// If array is empty, then do nothing (do not even write the tag)

--- a/tests/write_read.rs
+++ b/tests/write_read.rs
@@ -214,6 +214,18 @@ fn wr_packed_uint32(){
 }
 
 #[test]
+fn wr_packed_float(){
+    let v = vec![43, 54, 64, 234, 6123, 643];
+    let mut buf = Vec::new();
+    {
+        let mut w = Writer::new(&mut buf);
+        w.write_packed_fixed(&v).unwrap();
+    }
+    let mut r = BytesReader::from_bytes(&buf);
+    assert_eq!(v, r.read_packed_fixed(&buf).unwrap());
+}
+
+#[test]
 fn wr_map(){
     let v = {
         let mut v = HashMap::new();


### PR DESCRIPTION
When a field has a fixed size, is repeated and packed, we can directly read its data as a slice of data.
So instead of reading each item one by one we convert the entire slice at once. On top of that, we do not need to allocate data and can work with Cow<[M]> instead.

This has a much better perf:

```
 name                         master ns/iter  fixed ns/iter  diff ns/iter   diff %
 read_repeated_packed_float   19,008          277                 -18,731  -98.54%
 write_repeated_packed_float  9,619           2,841                -6,778  -70.46%
```