### PR TITLE
Sanitize default values

### DIFF
--- a/codegen/src/parser.rs
+++ b/codegen/src/parser.rs
@@ -53,8 +53,8 @@ named!(reserved_names<Vec<String>>,
 named!(key_val<(&str, &str)>, 
        do_parse!(tag!("[") >> many0!(br) >> 
                  key: word_ref >> many0!(br) >> tag!("=") >> many0!(br) >> 
-                 value: word_ref >> many0!(br) >> tag!("]") >> many0!(br) >>
-                 ((key, value)) ));
+                 value: map_res!(is_not!("]"), str::from_utf8) >> tag!("]") >> many0!(br) >>
+                 ((key, value.trim())) ));
 
 named!(frequency<Frequency>,
        alt!(tag!("optional") => { |_| Frequency::Optional } |


### PR DESCRIPTION
Force a nice rust value conversion (`::std::f32::INFINITY`, `0f32`, `Cow::Borrowed("my string")` ...) when a default value is set