### PR TITLE
encapsulate oneofs into mod_Message module

### DIFF
--- a/codegen/src/parser.rs
+++ b/codegen/src/parser.rs
@@ -93,6 +93,7 @@ named!(one_of<OneOf>,
                  (OneOf {
                      name: name,
                      fields: fields,
+                     package: "".to_string(),
                  }) ));
 
 named!(message_field<Field>, 

--- a/examples/codegen_example.rs
+++ b/examples/codegen_example.rs
@@ -4,7 +4,8 @@ mod codegen;
 
 use std::borrow::Cow;
 
-use codegen::data_types::{self, FooMessage, OneOftest_oneof};
+use codegen::data_types::{self, FooMessage};
+use codegen::data_types::mod_FooMessage::OneOftest_oneof;
 
 // Imported fields contain package a.b, which is translated into
 // mod_a::mod_b rust module


### PR DESCRIPTION
Closes #39 

Like for nested enums and messages, oneofs are now encapsulated in `mod_MessageName` module.

@stevedonovan, is it ok for you