### PR TITLE
errors: add Into<::std::io::Error> conversion

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -34,3 +34,16 @@ error_chain! {
         }
     }
 }
+
+impl Into<::std::io::Error> for Error {
+    fn into(self) -> ::std::io::Error {
+        use ::std::io;
+        match self {
+            Error(ErrorKind::Io(x), _) => x,
+            Error(ErrorKind::Eof, _) => io::ErrorKind::UnexpectedEof.into(),
+            Error(ErrorKind::Utf8(x), _) => io::Error::new(io::ErrorKind::InvalidData, x.utf8_error()),
+            Error(ErrorKind::StrUtf8(x), _) => io::Error::new(io::ErrorKind::InvalidData, x),
+            x => io::Error::new(io::ErrorKind::Other, x),
+        }
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,7 +5,6 @@
 error_chain! {
     foreign_links {
         Io(::std::io::Error);
-        Utf8(::std::string::FromUtf8Error);
         StrUtf8(::std::str::Utf8Error);
     }
     errors {
@@ -26,7 +25,6 @@ error_chain! {
         ParseMessage(s: String) {
             description("error while parsing message")
             display("error while parsing message: {}", s)
-
         }
         Map(tag: u8) {
             description("unexpected map tag")
@@ -41,7 +39,6 @@ impl Into<::std::io::Error> for Error {
         match self {
             Error(ErrorKind::Io(x), _) => x,
             Error(ErrorKind::Eof, _) => io::ErrorKind::UnexpectedEof.into(),
-            Error(ErrorKind::Utf8(x), _) => io::Error::new(io::ErrorKind::InvalidData, x.utf8_error()),
             Error(ErrorKind::StrUtf8(x), _) => io::Error::new(io::ErrorKind::InvalidData, x),
             x => io::Error::new(io::ErrorKind::Other, x),
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,9 +19,6 @@ error_chain! {
         Varint {
             description("cannot decode varint")
         }
-        Eof {
-            description("unexpected end of file")
-        }
         ParseMessage(s: String) {
             description("error while parsing message")
             display("error while parsing message: {}", s)
@@ -38,7 +35,6 @@ impl Into<::std::io::Error> for Error {
         use ::std::io;
         match self {
             Error(ErrorKind::Io(x), _) => x,
-            Error(ErrorKind::Eof, _) => io::ErrorKind::UnexpectedEof.into(),
             Error(ErrorKind::StrUtf8(x), _) => io::Error::new(io::ErrorKind::InvalidData, x),
             x => io::Error::new(io::ErrorKind::Other, x),
         }


### PR DESCRIPTION
This conversion helps when working with for example tokio-proto where
`Codec` must use `std::io::Error`.