### PR TITLE
Introduce clap for pb-rs cmdline parsing

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -7,3 +7,4 @@ description = "A converter from proto files into quick-protobuf compatible rust 
 [dependencies]
 nom = "2.0.1"
 error-chain = "0.8.1"
+clap = "2"

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -2,40 +2,36 @@
 extern crate nom;
 #[macro_use]
 extern crate error_chain;
+#[macro_use]
+extern crate clap;
 
 mod parser;
 mod types;
 mod errors;
 mod keywords;
 
-use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use clap::{App, Arg};
 use types::FileDescriptor;
 
 fn main() {
+    let matches = App::new("pb-rs").version(crate_version!())
+        .arg(Arg::with_name("INPUT").required(true).index(1).help("The .proto file used to generate quick-protobuf code").validator(|x| ends_with_proto(x)))
+        .get_matches();
 
-    let args = env::args().collect::<Vec<_>>();
-    let usage = format!("{} <file.proto>", args[0]);
-
-    if args.len() == 0 {
-        println!("{}", usage);
-        return;
-    }
-
-    let in_file: PathBuf = args.get(1).map(|a| a.into()).unwrap();
-    match in_file.extension().and_then(|e| e.to_str()) {
-        Some("proto") => (),
-        _ => {
-            println!("{}", usage);
-            println!("\r\nExpecting an input file with 'proto' extension");
-            return;
-        }
-    }
-
+    let in_file: PathBuf = matches.value_of("INPUT").map(|a| a.to_string().into()).unwrap();
     let out_file = in_file.with_extension("rs");
 
     FileDescriptor::write_proto(&in_file, &out_file)
         .expect(&format!("Could not convert {} into {}", 
                          in_file.display(), out_file.display()));
 
+}
+
+fn ends_with_proto<P: AsRef<Path>>(path: P) -> Result<(), String> {
+    match path.as_ref().extension() {
+        Some(x) if x == "proto" => Ok(()),
+        Some(x) => Err(format!("Expected path with extension 'proto', not: '{}'", x.to_string_lossy())),
+        None => Err(format!("Expected path with extension 'proto'")),
+    }
 }

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -12,20 +12,27 @@ mod keywords;
 
 use std::path::{Path, PathBuf};
 use clap::{App, Arg};
-use types::FileDescriptor;
+use types::{FileDescriptor, Config};
 
 fn main() {
     let matches = App::new("pb-rs").version(crate_version!())
         .arg(Arg::with_name("OUTPUT").required(false).long("output").short("o").help("Generated file name, defaults to INPUT with 'rs' extension").validator(|x| extension_matches(x, "rs")))
+        .arg(Arg::with_name("SINGLE_MOD").required(false).long("single-mod").short("s").help("Omit generation of modules for each package when there is only one package"))
         .arg(Arg::with_name("INPUT").required(true).index(1).help("The .proto file used to generate quick-protobuf code").validator(|x| extension_matches(x, "proto")))
         .get_matches();
 
     let in_file: PathBuf = matches.value_of("INPUT").map(|a| a.to_string().into()).unwrap();
     let out_file: PathBuf = matches.value_of("OUTPUT").map(|a| a.to_string().into()).unwrap_or(in_file.with_extension("rs"));
 
-    FileDescriptor::write_proto(&in_file, &out_file)
-        .expect(&format!("Could not convert {} into {}", 
-                         in_file.display(), out_file.display()));
+    let config = Config {
+        in_file: in_file,
+        out_file: out_file,
+        single_module: matches.is_present("SINGLE_MOD")
+    };
+
+    FileDescriptor::write_proto(&config)
+        .expect(&format!("Could not convert {} into {}",
+                         config.in_file.display(), config.out_file.display()));
 
 }
 

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -15,7 +15,10 @@ use clap::{App, Arg};
 use types::{FileDescriptor, Config};
 
 fn main() {
-    let matches = App::new("pb-rs").version(crate_version!())
+    let matches = App::new(crate_name!())
+        .about(crate_description!())
+        .author(crate_authors!("\n"))
+        .version(crate_version!())
         .arg(Arg::with_name("OUTPUT")
                 .required(false)
                 .long("output")

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -38,8 +38,12 @@ fn main() {
                 .validator(|x| extension_matches(x, "proto")))
         .get_matches();
 
-    let in_file: PathBuf = matches.value_of("INPUT").map(|a| a.to_string().into()).unwrap();
-    let out_file: PathBuf = matches.value_of("OUTPUT").map(|a| a.to_string().into()).unwrap_or(in_file.with_extension("rs"));
+    let in_file: PathBuf = matches.value_of("INPUT")
+        .map(|a| a.to_string().into()).unwrap();
+
+    let out_file: PathBuf = matches.value_of("OUTPUT")
+        .map(|a| a.to_string().into())
+        .unwrap_or(in_file.with_extension("rs"));
 
     let config = Config {
         in_file: in_file,

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -16,11 +16,12 @@ use types::FileDescriptor;
 
 fn main() {
     let matches = App::new("pb-rs").version(crate_version!())
-        .arg(Arg::with_name("INPUT").required(true).index(1).help("The .proto file used to generate quick-protobuf code").validator(|x| ends_with_proto(x)))
+        .arg(Arg::with_name("OUTPUT").required(false).long("output").short("o").help("Generated file name, defaults to INPUT with 'rs' extension").validator(|x| extension_matches(x, "rs")))
+        .arg(Arg::with_name("INPUT").required(true).index(1).help("The .proto file used to generate quick-protobuf code").validator(|x| extension_matches(x, "proto")))
         .get_matches();
 
     let in_file: PathBuf = matches.value_of("INPUT").map(|a| a.to_string().into()).unwrap();
-    let out_file = in_file.with_extension("rs");
+    let out_file: PathBuf = matches.value_of("OUTPUT").map(|a| a.to_string().into()).unwrap_or(in_file.with_extension("rs"));
 
     FileDescriptor::write_proto(&in_file, &out_file)
         .expect(&format!("Could not convert {} into {}", 
@@ -28,10 +29,10 @@ fn main() {
 
 }
 
-fn ends_with_proto<P: AsRef<Path>>(path: P) -> Result<(), String> {
+fn extension_matches<P: AsRef<Path>>(path: P, expected: &str) -> Result<(), String> {
     match path.as_ref().extension() {
-        Some(x) if x == "proto" => Ok(()),
-        Some(x) => Err(format!("Expected path with extension 'proto', not: '{}'", x.to_string_lossy())),
-        None => Err(format!("Expected path with extension 'proto'")),
+        Some(x) if x == expected => Ok(()),
+        Some(x) => Err(format!("Expected path with extension '{}', not: '{}'", expected, x.to_string_lossy())),
+        None => Err(format!("Expected path with extension '{}'", expected)),
     }
 }

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -16,9 +16,23 @@ use types::{FileDescriptor, Config};
 
 fn main() {
     let matches = App::new("pb-rs").version(crate_version!())
-        .arg(Arg::with_name("OUTPUT").required(false).long("output").short("o").takes_value(true).help("Generated file name, defaults to INPUT with 'rs' extension").validator(|x| extension_matches(x, "rs")))
-        .arg(Arg::with_name("SINGLE_MOD").required(false).long("single-mod").short("s").help("Omit generation of modules for each package when there is only one package"))
-        .arg(Arg::with_name("INPUT").required(true).index(1).help("The .proto file used to generate quick-protobuf code").validator(|x| extension_matches(x, "proto")))
+        .arg(Arg::with_name("OUTPUT")
+                .required(false)
+                .long("output")
+                .short("o")
+                .takes_value(true)
+                .help("Generated file name, defaults to INPUT with 'rs' extension")
+                .validator(|x| extension_matches(x, "rs")))
+        .arg(Arg::with_name("SINGLE_MOD")
+                .required(false)
+                .long("single-mod")
+                .short("s")
+                .help("Omit generation of modules for each package when there is only one package"))
+        .arg(Arg::with_name("INPUT")
+                .required(true)
+                .index(1)
+                .help("The .proto file used to generate quick-protobuf code")
+                .validator(|x| extension_matches(x, "proto")))
         .get_matches();
 
     let in_file: PathBuf = matches.value_of("INPUT").map(|a| a.to_string().into()).unwrap();

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -16,7 +16,7 @@ use types::{FileDescriptor, Config};
 
 fn main() {
     let matches = App::new("pb-rs").version(crate_version!())
-        .arg(Arg::with_name("OUTPUT").required(false).long("output").short("o").help("Generated file name, defaults to INPUT with 'rs' extension").validator(|x| extension_matches(x, "rs")))
+        .arg(Arg::with_name("OUTPUT").required(false).long("output").short("o").takes_value(true).help("Generated file name, defaults to INPUT with 'rs' extension").validator(|x| extension_matches(x, "rs")))
         .arg(Arg::with_name("SINGLE_MOD").required(false).long("single-mod").short("s").help("Omit generation of modules for each package when there is only one package"))
         .arg(Arg::with_name("INPUT").required(true).index(1).help("The .proto file used to generate quick-protobuf code").validator(|x| extension_matches(x, "proto")))
         .get_matches();

--- a/codegen/src/types.rs
+++ b/codegen/src/types.rs
@@ -1035,6 +1035,12 @@ impl OneOf {
 
 }
 
+pub struct Config<P: AsRef<Path>> {
+    pub in_file: P,
+    pub out_file: P,
+    pub single_module: bool,
+}
+
 #[derive(Debug, Default)]
 pub struct FileDescriptor {
     pub import_paths: Vec<PathBuf>,
@@ -1046,31 +1052,31 @@ pub struct FileDescriptor {
 
 impl FileDescriptor {
 
-    pub fn write_proto<P: AsRef<Path>>(in_file: P, out_file: P) -> Result<()> {
-        let mut desc = FileDescriptor::read_proto(&in_file)?;
-        desc.fetch_imports(in_file.as_ref())?;
+    pub fn write_proto<P: AsRef<Path>>(config: &Config<P>) -> Result<()> {
+        let mut desc = FileDescriptor::read_proto(&config.in_file)?;
+        desc.fetch_imports(config.in_file.as_ref())?;
 
         let mut leaf_messages = Vec::new();
         break_cycles(&mut desc.messages, &mut leaf_messages);
 
-        desc.sanity_checks(in_file.as_ref())?;
+        desc.sanity_checks(config.in_file.as_ref())?;
         desc.set_enums();
         desc.set_defaults();
         desc.sanitize_names();
 
-        let name = in_file.as_ref().file_name().and_then(|e| e.to_str()).unwrap();
+        let name = config.in_file.as_ref().file_name().and_then(|e| e.to_str()).unwrap();
         let out_file = {
-            let mut file_stem: String = out_file.as_ref().file_stem()
+            let mut file_stem: String = config.out_file.as_ref().file_stem()
                 .and_then(|f| f.to_str())
                 .map(|s| s.to_string())
-                .ok_or_else::<Error, _>(|| ErrorKind::OutputFile(out_file.as_ref().to_owned()).into())?;
+                .ok_or_else::<Error, _>(|| ErrorKind::OutputFile(config.out_file.as_ref().to_owned()).into())?;
 
             file_stem = file_stem.chars().map(|c| match c {
                 'a'...'z' | 'A'...'Z' | '0'...'9' | '_' => c,
                 _ => '_',
             }).collect();
             sanitize_keyword(&mut file_stem);
-            out_file.as_ref().with_file_name(format!("{}.rs", file_stem))
+            config.out_file.as_ref().with_file_name(format!("{}.rs", file_stem))
         };
         let mut w = BufWriter::new(File::create(out_file)?);
         desc.write(&mut w, name)

--- a/codegen/src/types.rs
+++ b/codegen/src/types.rs
@@ -1064,6 +1064,10 @@ impl FileDescriptor {
         desc.set_defaults();
         desc.sanitize_names();
 
+        if config.single_module {
+            desc.package = "".to_string();
+        }
+
         let name = config.in_file.as_ref().file_name().and_then(|e| e.to_str()).unwrap();
         let out_file = {
             let mut file_stem: String = config.out_file.as_ref().file_stem()


### PR DESCRIPTION
Related to issue #27, this PR lays out the foundation for more options with the use of [clap-rs](https://github.com/kbknapp/clap-rs). There is one new option already implemented (--single-mod or -s). While probably poorly named it does what I hoped it to do: I do not wish there to be modules mod_A.mod_B.mod_C as the source of my .proto file has.

One thing that worries me is testing, which should probably be thougth out before adding any more options. My current implementation of the option is probably too short sighted at the moment, even though it seems to WorksForMe&copy; :)

In addition to testing, you'll probably notice that I used overly long lines to describe the options. I'd wish `rustfmt` was used so that there would be no worrying about the formatting :) However, as I tried to use it I ran into [rustfmt#1265](https://github.com/rust-lang-nursery/rustfmt/issues/1265) which makes using it quite unbearable in the presence of generated code files. For example: time to process a single generated `examples/codegen/data_types.rs` is 1m30s which can be easily optimized to 1min, but that's still way too long.