### PR TITLE
bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/quick-protobuf"
 repository = "https://github.com/tafia/quick-protobuf"
 
 [dependencies]
-error-chain = "0.8.1"
-byteorder = "1.0.0"
+error-chain = "0.11.0"
+byteorder = "1.1.0"
 
 [dev-dependencies]
-lazy_static = "0.2.2"
+lazy_static = "0.2.10"

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Johann Tuffe"]
 description = "A converter from proto files into quick-protobuf compatible rust module"
 
 [dependencies]
-nom = "2.0.1"
-error-chain = "0.8.1"
-clap = "2"
+nom = "3.2.1"
+error-chain = "0.11.0"
+clap = "2.27.1"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -30,6 +30,8 @@ error_chain! {
     }
 }
 
+unsafe impl Sync for Error {}
+
 impl Into<::std::io::Error> for Error {
     fn into(self) -> ::std::io::Error {
         use ::std::io;


### PR DESCRIPTION
In particular bump to using error-chain 0.11.0 by enforcing `Sync` for `Error`.