### PR TITLE
Fix reserved fields support

### DIFF
--- a/codegen/src/errors.rs
+++ b/codegen/src/errors.rs
@@ -23,7 +23,8 @@ error_chain! {
             cause("import definition might be invalid, some characters may not be supported")
         }
         EmptyRead {
-            description("No messages or enums were read; either there was no input or there were only unsupported structures")
+            description("No messages or enums were read;\
+                         either there was no input or there were only unsupported structures")
         }
     }
 }

--- a/codegen/src/keywords.rs
+++ b/codegen/src/keywords.rs
@@ -82,10 +82,14 @@ pub fn sanitize_keyword(ident: &mut String) {
     if !ident.contains('.') && RUST_KEYWORDS.contains(&&**ident) {
         ident.push_str("_pb");
     } else {
-        *ident = ident.split('.').map(|s| if RUST_KEYWORDS.contains(&s) {
-            format!("{}_pb", s)
-        } else {
-            s.to_string()
-        }).collect::<Vec<_>>().join(".");
+        *ident = ident
+            .split('.')
+            .map(|s| if RUST_KEYWORDS.contains(&s) {
+                format!("{}_pb", s)
+            } else {
+                s.to_string()
+            })
+            .collect::<Vec<_>>()
+            .join(".");
     }
 }

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -1,9 +1,9 @@
 #[macro_use]
-extern crate nom;
+extern crate clap;
 #[macro_use]
 extern crate error_chain;
 #[macro_use]
-extern crate clap;
+extern crate nom;
 
 mod parser;
 mod types;
@@ -12,7 +12,7 @@ mod keywords;
 
 use std::path::{Path, PathBuf};
 use clap::{App, Arg};
-use types::{FileDescriptor, Config};
+use types::{Config, FileDescriptor};
 
 use errors::*;
 
@@ -21,55 +21,70 @@ fn run() -> Result<()> {
         .about(crate_description!())
         .author(crate_authors!("\n"))
         .version(crate_version!())
-        .arg(Arg::with_name("OUTPUT")
+        .arg(
+            Arg::with_name("OUTPUT")
                 .required(false)
                 .long("output")
                 .short("o")
                 .takes_value(true)
                 .help("Generated file name, defaults to INPUT with 'rs' extension")
-                .validator(|x| extension_matches(x, "rs")))
-        .arg(Arg::with_name("OUTPUT_DIR")
+                .validator(|x| extension_matches(x, "rs")),
+        )
+        .arg(
+            Arg::with_name("OUTPUT_DIR")
                 .required(false)
                 .long("output_directory")
                 .short("d")
                 .takes_value(true)
-                .help("Output directory of generated code"))
-        .arg(Arg::with_name("INCLUDE_PATH")
+                .help("Output directory of generated code"),
+        )
+        .arg(
+            Arg::with_name("INCLUDE_PATH")
                 .required(false)
                 .long("include")
                 .short("I")
                 .takes_value(true)
-                .help("Path to search for imported protobufs"))
-        .arg(Arg::with_name("SINGLE_MOD")
+                .help("Path to search for imported protobufs"),
+        )
+        .arg(
+            Arg::with_name("SINGLE_MOD")
                 .required(false)
                 .long("single-mod")
                 .short("s")
-                .help("Omit generation of modules for each package when there is only one package"))
-        .arg(Arg::with_name("NO_OUTPUT")
+                .help("Omit generation of modules for each package when there is only one package"),
+        )
+        .arg(
+            Arg::with_name("NO_OUTPUT")
                 .required(false)
                 .long("no-output")
                 .short("n")
-                .help("Show enums and messages in this .proto file, including those imported. No code generated"))
-        .arg(Arg::with_name("INPUT")
+                .help(
+                    "Show enums and messages in this .proto file, including those imported. \
+                     No code generated",
+                ),
+        )
+        .arg(
+            Arg::with_name("INPUT")
                 .multiple(true)
                 .help("The .proto files used to generate quick-protobuf code")
-                .validator(|x| extension_matches(x, "proto")))
+                .validator(|x| extension_matches(x, "proto")),
+        )
         .get_matches();
 
-    let in_files = path_vec(values_t!(matches,"INPUT",String));
+    let in_files = path_vec(values_t!(matches, "INPUT", String));
     if in_files.is_empty() {
         bail!("no .proto files provided!");
     }
 
     for f in &in_files {
-        if ! f.exists() {
+        if !f.exists() {
             bail!(format!("input file {:?} does not exist", f));
         }
     }
 
-    let mut include_path = path_vec(values_t!(matches,"INCLUDE_PATH",String));
+    let mut include_path = path_vec(values_t!(matches, "INCLUDE_PATH", String));
     let default = PathBuf::from(".");
-    if include_path.is_empty() || ! include_path.contains(&default) {
+    if include_path.is_empty() || !include_path.contains(&default) {
         include_path.push(default);
     }
 
@@ -82,10 +97,10 @@ fn run() -> Result<()> {
 
         if let Some(ofile) = matches.value_of("OUTPUT") {
             out_file = PathBuf::from(ofile);
-        }
-        else if let Some(dir) = matches.value_of("OUTPUT_DIR") {
+        } else if let Some(dir) = matches.value_of("OUTPUT_DIR") {
             let mut directory = PathBuf::from(dir);
-            if ! directory.is_dir() { // we can create? But only last dir
+            if !directory.is_dir() {
+                // we can create? But only last dir
                 bail!(format!("output directory {:?} does not exist", directory));
             }
             directory.push(out_file.file_name().unwrap());
@@ -100,10 +115,13 @@ fn run() -> Result<()> {
             no_output: matches.is_present("NO_OUTPUT"),
         };
 
-        FileDescriptor::write_proto(&config)
-            .chain_err(|| format!("Could not convert {} into {}",
-                             config.in_file.display(), config.out_file.display()))?;
-
+        FileDescriptor::write_proto(&config).chain_err(|| {
+            format!(
+                "Could not convert {} into {}",
+                config.in_file.display(),
+                config.out_file.display()
+            )
+        })?;
     }
     Ok(())
 }
@@ -111,14 +129,21 @@ fn run() -> Result<()> {
 fn extension_matches<P: AsRef<Path>>(path: P, expected: &str) -> std::result::Result<(), String> {
     match path.as_ref().extension() {
         Some(x) if x == expected => Ok(()),
-        Some(x) => Err(format!("Expected path with extension '{}', not: '{}'", expected, x.to_string_lossy())),
+        Some(x) => Err(format!(
+            "Expected path with extension '{}', not: '{}'",
+            expected,
+            x.to_string_lossy()
+        )),
         None => Err(format!("Expected path with extension '{}'", expected)),
     }
 }
 
-fn path_vec(maybe_vec: std::result::Result<Vec<String>,clap::Error>) -> Vec<PathBuf> {
-    maybe_vec.unwrap_or_else(|_| Vec::new())
-        .iter().map(|s| s.into()).collect()
+fn path_vec(maybe_vec: std::result::Result<Vec<String>, clap::Error>) -> Vec<PathBuf> {
+    maybe_vec
+        .unwrap_or_else(|_| Vec::new())
+        .iter()
+        .map(|s| s.into())
+        .collect()
 }
 
 

--- a/codegen/src/parser.rs
+++ b/codegen/src/parser.rs
@@ -1,70 +1,129 @@
 use std::str;
 use std::path::{Path, PathBuf};
 
-use types::{Frequency, Field, Message, Enumerator, OneOf, FileDescriptor, Syntax, FieldType};
-use nom::{multispace, digit, hex_digit};
+use types::{Enumerator, Field, FieldType, FileDescriptor, Frequency, Message, OneOf, Syntax};
+use nom::{digit, hex_digit, multispace};
 
 fn is_word(b: u8) -> bool {
     match b {
         b'a'...b'z' | b'A'...b'Z' | b'0'...b'9' | b'_' | b'.' => true,
-        _ => false
+        _ => false,
     }
 }
 
-named!(word<String>, map_res!(take_while!(is_word), |b: &[u8]| String::from_utf8(b.to_vec())));
-named!(word_ref<&str>, map_res!(take_while!(is_word), str::from_utf8));
+named!(
+    word<String>,
+    map_res!(
+        take_while!(is_word),
+        |b: &[u8]| String::from_utf8(b.to_vec())
+    )
+);
+named!(
+    word_ref<&str>,
+    map_res!(take_while!(is_word), str::from_utf8)
+);
 
-named!(comment<()>, do_parse!(tag!("//") >> take_until_and_consume!("\n") >> ()));
-named!(block_comment<()>, do_parse!(tag!("/*") >> take_until_and_consume!("*/") >> ()));
+named!(
+    hex_integer<i32>,
+    do_parse!(
+        tag!("0x") >>
+        num: map_res!(
+            map_res!(hex_digit,str::from_utf8),
+            |s| i32::from_str_radix(s,16)
+        ) >> (num)
+    )
+);
+
+named!(
+    integer<i32>,
+    map_res!(map_res!(digit, str::from_utf8), str::FromStr::from_str)
+);
+
+named!(
+    comment<()>,
+    do_parse!(tag!("//") >> take_until_and_consume!("\n") >> ())
+);
+named!(
+    block_comment<()>,
+    do_parse!(tag!("/*") >> take_until_and_consume!("*/") >> ())
+);
 
 /// word break: multispace or comment
-named!(br<()>, alt!(map!(multispace, |_| ()) | comment | block_comment));
+named!(
+    br<()>,
+    alt!(map!(multispace, |_| ()) | comment | block_comment)
+);
 
-named!(syntax<Syntax>,
-       do_parse!(tag!("syntax") >> many0!(br) >> tag!("=") >> many0!(br) >>
+named!(
+    syntax<Syntax>,
+    do_parse!(tag!("syntax") >> many0!(br) >> tag!("=") >> many0!(br) >>
                  proto: alt!(tag!("\"proto2\"") => { |_| Syntax::Proto2 } |
                              tag!("\"proto3\"") => { |_| Syntax::Proto3 }) >>
                  many0!(br) >> tag!(";") >>
-                 (proto) ));
+                 (proto) )
+);
 
-named!(import<PathBuf>,
-       do_parse!(tag!("import")>> many1!(br) >> tag!("\"") >>
-                 path: map!(map_res!(take_until!("\""), str::from_utf8), |s| Path::new(s).into()) >> tag!("\"") >>
+named!(
+    import<PathBuf>,
+    do_parse!(tag!("import") >> many1!(br) >> tag!("\"") >>
+                 path: map!(map_res!(take_until!("\""), str::from_utf8),
+                                     |s| Path::new(s).into()) >> tag!("\"") >>
                  many0!(br) >> tag!(";") >>
-                 (path) ));
+                 (path) )
+);
 
-named!(package<String>,
-       do_parse!(tag!("package") >> many1!(br) >> package: word >> many0!(br) >> tag!(";") >>
-                 (package) ));
+named!(
+    package<String>,
+    do_parse!(
+        tag!("package") >> many1!(br) >> package: word >> many0!(br) >> tag!(";") >> (package)
+    )
+);
 
-named!(reserved_nums<Vec<i32>>,
-       do_parse!(tag!("reserved") >> many1!(br) >>
-                 nums: many1!(do_parse!(num: map_res!(map_res!(digit, str::from_utf8), str::FromStr::from_str) >>
-                                        many0!(alt!(br | tag!(",") => { |_| () })) >> (num))) >> 
+named!(
+    num_range<Vec<i32>>,
+    do_parse!(
+        from_: integer >> many1!(br) >> tag!("to") >> many1!(br) >> to_: integer
+            >> ((from_..(to_ + 1)).collect())
+    )
+);
+
+named!(
+    reserved_nums<Vec<i32>>,
+    do_parse!(tag!("reserved") >> many1!(br) >>
+                 nums: separated_list!(do_parse!(many0!(br) >> tag!(",") >> many0!(br) >> (())),
+                                       alt!(num_range | integer => { |i| vec![i] })) >>
                  many0!(br) >> tag!(";") >>
-                (nums) ));
+                (nums.into_iter().flat_map(|v| v.into_iter()).collect()) )
+);
 
-named!(reserved_names<Vec<String>>,
-       do_parse!(tag!("reserved") >> many1!(br) >>
+named!(
+    reserved_names<Vec<String>>,
+    do_parse!(tag!("reserved") >> many1!(br) >>
                  names: many1!(do_parse!(tag!("\"") >> name: word >> tag!("\"") >>
                                         many0!(alt!(br | tag!(",") => { |_| () })) >>
                                         (name))) >>
                  many0!(br) >> tag!(";") >>
-                (names) ));
+                (names) )
+);
 
-named!(key_val<(&str, &str)>,
-       do_parse!(tag!("[") >> many0!(br) >>
+named!(
+    key_val<(&str, &str)>,
+    do_parse!(tag!("[") >> many0!(br) >>
                  key: word_ref >> many0!(br) >> tag!("=") >> many0!(br) >>
                  value: map_res!(is_not!("]"), str::from_utf8) >> tag!("]") >> many0!(br) >>
-                 ((key, value.trim())) ));
+                 ((key, value.trim())) )
+);
 
-named!(frequency<Frequency>,
-       alt!(tag!("optional") => { |_| Frequency::Optional } |
+named!(
+    frequency<Frequency>,
+    alt!(tag!("optional") => { |_| Frequency::Optional } |
             tag!("repeated") => { |_| Frequency::Repeated } |
-            tag!("required") => { |_| Frequency::Required } ));
+            tag!("required") => { |_| Frequency::Required } )
+);
 
-named!(field_type<FieldType>,
-       alt!(tag!("int32") => { |_| FieldType::Int32 } |
+named!(
+    field_type<FieldType>,
+    alt!(tag!("int32") => { |_| FieldType::Int32 } |
             tag!("int64") => { |_| FieldType::Int64 } |
             tag!("uint32") => { |_| FieldType::Uint32 } |
             tag!("uint64") => { |_| FieldType::Uint64 } |
@@ -80,16 +139,20 @@ named!(field_type<FieldType>,
             tag!("float") => { |_| FieldType::Float } |
             tag!("double") => { |_| FieldType::Double } |
             map_field => { |(k, v)| FieldType::Map(Box::new((k, v))) } |
-            word => { |w| FieldType::Message(w) }));
+            word => { |w| FieldType::Message(w) })
+);
 
-named!(map_field<(FieldType, FieldType)>,
-       do_parse!(tag!("map") >> many0!(br) >> tag!("<") >> many0!(br) >>
-                 key: field_type >> many0!(br) >> tag!(",") >> many0!(br) >>
-                 value: field_type >> tag!(">") >>
-                 ((key, value)) ));
+named!(
+    map_field<(FieldType, FieldType)>,
+    do_parse!(
+        tag!("map") >> many0!(br) >> tag!("<") >> many0!(br) >> key: field_type >> many0!(br)
+            >> tag!(",") >> many0!(br) >> value: field_type >> tag!(">") >> ((key, value))
+    )
+);
 
-named!(one_of<OneOf>,
-       do_parse!(tag!("oneof") >> many1!(br) >>
+named!(
+    one_of<OneOf>,
+    do_parse!(tag!("oneof") >> many1!(br) >>
                  name: word >> many0!(br) >> tag!("{") >>
                  fields: many1!(message_field) >> many0!(br) >> tag!("}") >> many0!(br) >>
                  (OneOf {
@@ -98,13 +161,15 @@ named!(one_of<OneOf>,
                      package: "".to_string(),
                      module: "".to_string(),
                      imported: false
-                 }) ));
+                 }) )
+);
 
-named!(message_field<Field>,
-       do_parse!(frequency: opt!(frequency) >> many0!(br) >>
+named!(
+    message_field<Field>,
+    do_parse!(frequency: opt!(frequency) >> many0!(br) >>
                  typ: field_type >> many1!(br) >>
                  name: word >> many0!(br) >> tag!("=") >> many0!(br) >>
-                 number: map_res!(map_res!(digit, str::from_utf8), str::FromStr::from_str) >> many0!(br) >>
+                 number: integer >> many0!(br) >>
                  key_vals: many0!(key_val) >> tag!(";") >>
                  (Field {
                       name: name,
@@ -123,7 +188,8 @@ named!(message_field<Field>,
                                   .find(|&&(k, _)| k == "deprecated")
                                   .map_or(false, |&(_, v)| str::FromStr::from_str(v)
                                           .expect("Cannot parse Deprecated value")),
-                 }) ));
+                 }) )
+);
 
 enum MessageEvent {
     Message(Message),
@@ -135,61 +201,66 @@ enum MessageEvent {
     Ignore,
 }
 
-named!(message_event<MessageEvent>, alt!(reserved_nums => { |r| MessageEvent::ReservedNums(r) } |
+named!(
+    message_event<MessageEvent>,
+    alt!(reserved_nums => { |r| MessageEvent::ReservedNums(r) } |
                                          reserved_names => { |r| MessageEvent::ReservedNames(r) } |
                                          message_field => { |f| MessageEvent::Field(f) } |
                                          message => { |m| MessageEvent::Message(m) } |
                                          enumerator => { |e| MessageEvent::Enumerator(e) } |
                                          one_of => { |o| MessageEvent::OneOf(o) } |
-                                         br => { |_| MessageEvent::Ignore }));
+                                         br => { |_| MessageEvent::Ignore })
+);
 
-named!(message_events<(String, Vec<MessageEvent>)>,
-       do_parse!(tag!("message") >> many1!(br) >>
+named!(
+    message_events<(String, Vec<MessageEvent>)>,
+    do_parse!(tag!("message") >> many1!(br) >>
                  name: word >> many0!(br) >>
                  tag!("{") >> many0!(br) >>
                  events: many0!(message_event) >>
                  many0!(br) >> tag!("}") >>
                  many0!(br) >> many0!(tag!(";")) >>
-                 ((name, events)) ));
+                 ((name, events)) )
+);
 
-named!(message<Message>,
-       map!(message_events, |(name, events): (String, Vec<MessageEvent>)| {
-           let mut msg = Message { name: name.clone(), .. Message::default() };
-           for e in events {
-               match e {
-                   MessageEvent::Field(f) => msg.fields.push(f),
-                   MessageEvent::ReservedNums(r) => msg.reserved_nums = Some(r),
-                   MessageEvent::ReservedNames(r) => msg.reserved_names = Some(r),
-                   MessageEvent::Message(m) => msg.messages.push(m),
-                   MessageEvent::Enumerator(e) => msg.enums.push(e),
-                   MessageEvent::OneOf(o) => msg.oneofs.push(o),
-                   MessageEvent::Ignore => (),
-               }
-           }
-           msg
-       }));
+named!(
+    message<Message>,
+    map!(
+        message_events,
+        |(name, events): (String, Vec<MessageEvent>)| {
+            let mut msg = Message {
+                name: name.clone(),
+                ..Message::default()
+            };
+            for e in events {
+                match e {
+                    MessageEvent::Field(f) => msg.fields.push(f),
+                    MessageEvent::ReservedNums(r) => msg.reserved_nums = Some(r),
+                    MessageEvent::ReservedNames(r) => msg.reserved_names = Some(r),
+                    MessageEvent::Message(m) => msg.messages.push(m),
+                    MessageEvent::Enumerator(e) => msg.enums.push(e),
+                    MessageEvent::OneOf(o) => msg.oneofs.push(o),
+                    MessageEvent::Ignore => (),
+                }
+            }
+            msg
+        }
+    )
+);
 
-named!(hex_integer<i32>,
-    do_parse!(
-        tag!("0x") >>
-        num: map_res!(
-            map_res!(hex_digit,str::from_utf8),
-            |s| i32::from_str_radix(s,16)
-        ) >> (num)
-    ));
-
-named!(integer<i32>,  map_res!( map_res!(digit,str::from_utf8), str::FromStr::from_str));
-
-named!(enum_field<(String, i32)>,
-       do_parse!(name: word >> many0!(br) >>
+named!(
+    enum_field<(String, i32)>,
+    do_parse!(name: word >> many0!(br) >>
                  tag!("=") >> many0!(br) >>
                  number: alt!(hex_integer | integer) >> many0!(br) >>
                  tag!(";") >> many0!(br) >>
-                 ((name, number))));
+                 ((name, number)))
+);
 
 
-named!(enumerator<Enumerator>,
-       do_parse!(tag!("enum") >> many1!(br) >> name: word >> many0!(br) >>
+named!(
+    enumerator<Enumerator>,
+    do_parse!(tag!("enum") >> many1!(br) >> name: word >> many0!(br) >>
                  tag!("{") >> many0!(br) >> fields: many0!(enum_field) >> many0!(br) >> tag!("}") >>
                  many0!(br) >> many0!(tag!(";")) >>
                  (Enumerator {
@@ -198,14 +269,21 @@ named!(enumerator<Enumerator>,
                      imported: false,
                      package: "".to_string(),
                      module: "".to_string()
-                 })));
+                 }))
+);
 
-named!(option_ignore<()>,
-       do_parse!(tag!("option") >> many1!(br) >> take_until_and_consume!(";") >> ()));
+named!(
+    option_ignore<()>,
+    do_parse!(tag!("option") >> many1!(br) >> take_until_and_consume!(";") >> ())
+);
 
-named!(service_ignore<()>,
-       do_parse!(tag!("service") >> many1!(br) >> word >> many0!(br) >> tag!("{") >>
-                 take_until_and_consume!("}") >> ()));
+named!(
+    service_ignore<()>,
+    do_parse!(
+        tag!("service") >> many1!(br) >> word >> many0!(br) >> tag!("{")
+            >> take_until_and_consume!("}") >> ()
+    )
+);
 
 enum Event {
     Syntax(Syntax),
@@ -213,18 +291,20 @@ enum Event {
     Package(String),
     Message(Message),
     Enum(Enumerator),
-    Ignore
+    Ignore,
 }
 
-named!(event<Event>,
-       alt!(syntax => { |s| Event::Syntax(s) } |
+named!(
+    event<Event>,
+    alt!(syntax => { |s| Event::Syntax(s) } |
             import => { |i| Event::Import(i) } |
             package => { |p| Event::Package(p) } |
             message => { |m| Event::Message(m) } |
             enumerator => { |e| Event::Enum(e) } |
             option_ignore => { |_| Event::Ignore } |
             service_ignore => { |_| Event::Ignore } |
-            br => { |_| Event::Ignore }));
+            br => { |_| Event::Ignore })
+);
 
 named!(pub file_descriptor<FileDescriptor>,
        map!(many0!(event), |events: Vec<Event>| {
@@ -305,7 +385,10 @@ mod test {
     }
     "#;
         let desc = file_descriptor(msg.as_bytes()).to_full_result().unwrap();
-        assert_eq!(vec![Path::new("test_import_nested_imported_pb.proto")], desc.import_paths);
+        assert_eq!(
+            vec![Path::new("test_import_nested_imported_pb.proto")],
+            desc.import_paths
+        );
     }
 
     #[test]
@@ -384,7 +467,7 @@ mod test {
     #[test]
     fn test_reserved() {
         let msg = r#"message Sample {
-       reserved 4, 5;
+       reserved 4, 15, 17 to 20, 30;
        reserved "foo", "bar";
        uint64 age =1;
        bytes name =2;
@@ -392,11 +475,14 @@ mod test {
 
         let mess = message(msg.as_bytes());
         if let ::nom::IResult::Done(_, mess) = mess {
-            assert_eq!(Some(vec![4, 5]), mess.reserved_nums);
-            assert_eq!(Some(vec!["foo".to_string(), "bar".to_string()]), mess.reserved_names);
+            assert_eq!(Some(vec![4, 15, 17, 18, 19, 20, 30]), mess.reserved_nums);
+            assert_eq!(
+                Some(vec!["foo".to_string(), "bar".to_string()]),
+                mess.reserved_names
+            );
             assert_eq!(2, mess.fields.len());
         } else {
-            panic!("Could not parse reserved_num message");
+            panic!("Could not parse reserved fields message");
         }
     }
 


### PR DESCRIPTION
The PR is actually polluted by a rustfmt but this should fix issues with reserved fields:
- both reserved nums and reserved names were not checking for ending `;` tag
- reserved nums were not supporting ranges like

   ```
   reserved 1, 2, 5 to 9, 15
   ```

relevant change is startng here:
https://github.com/tafia/quick-protobuf/compare/issue77?expand=1#diff-161ca5ad7871c529df91b4f9d002226fR82


