### PR TITLE
Replace from_reader impl with MessageRead trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,17 @@ fn main() {
     // Use the generated module fns with the reader to convert your data into rust structs.
     //
     // Depending on your input file, the message can or not be prefixed with the encoded length
-    // for instance, a *stream* which contains several messages generally split them using this 
+    // for instance, a *stream* which contains several messages generally split them using this
     // technique (see https://developers.google.com/protocol-buffers/docs/techniques#streaming)
     //
     // To read a message without a length prefix you can directly call `FooBar::from_reader`:
     // let foobar = reader.read(FooBar::from_reader).expect("Cannot read FooBar message");
     // 
     // Else to read a length then a message, you can use:
-    let foobar = reader.read(|r, b| r.read_message(b, FooBar::from_reader))
+    let foobar: FooBar = reader.read(|r, b| r.read_message(b))
         .expect("Cannot read FooBar message");
+    // Reader::read_message uses `FooBar::from_reader` internally through the `MessageRead`
+    // trait.
 
     println!("Found {} foos and {} bars!", foobar.foos.len(), foobar.bars.len());
 }

--- a/codegen/src/types.rs
+++ b/codegen/src/types.rs
@@ -257,7 +257,7 @@ impl FieldType {
         Ok(match *self {
             FieldType::Message(ref msg) => match self.find_message(&desc.messages) {
                 Some(m) => {
-                    let m = format!("r.read_message(bytes, {}{}::from_reader)", m.get_modules(desc), m.name);
+                    let m = format!("r.read_message::<{}{}>(bytes)", m.get_modules(desc), m.name);
                     (m.clone(), m)
                 }
                 None => bail!(format!("Could not find message {}", msg))
@@ -662,8 +662,8 @@ impl Message {
 
     fn write_impl_message_read<W: Write>(&self, w: &mut W, desc: &FileDescriptor) -> Result<()> {
         if self.is_unit() {
-            writeln!(w, "impl {} {{", self.name)?;
-            writeln!(w, "    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {{")?;
+            writeln!(w, "impl<'a> MessageRead<'a> for {} {{", self.name)?;
+            writeln!(w, "    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {{")?;
             writeln!(w, "        r.read_to_end();")?;
             writeln!(w, "        Ok(Self::default())")?;
             writeln!(w, "    }}")?;
@@ -672,11 +672,11 @@ impl Message {
         }
 
         if self.has_lifetime(desc) {
-            writeln!(w, "impl<'a> {}<'a> {{", self.name)?;
-            writeln!(w, "    pub fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {{")?;
+            writeln!(w, "impl<'a> MessageRead<'a> for {}<'a> {{", self.name)?;
+            writeln!(w, "    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {{")?;
         } else {
-            writeln!(w, "impl {} {{", self.name)?;
-            writeln!(w, "    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {{")?;
+            writeln!(w, "impl<'a> MessageRead<'a> for {} {{", self.name)?;
+            writeln!(w, "    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {{")?;
         }
 
         let unregular_defaults = self.fields.iter()
@@ -1300,7 +1300,7 @@ impl FileDescriptor {
 
     fn write_uses<W: Write>(&self, w: &mut W) -> Result<()> {
         if self.messages.iter().all(|m| m.is_unit()) {
-            writeln!(w, "use quick_protobuf::{{BytesReader, Result, MessageWrite}};")?;
+            writeln!(w, "use quick_protobuf::{{BytesReader, Result, MessageRead, MessageWrite}};")?;
             return Ok(());
         }
         writeln!(w, "use std::io::Write;")?;
@@ -1314,7 +1314,7 @@ impl FileDescriptor {
                                     .any(|f| f.typ.is_map())) {
             writeln!(w, "use std::collections::HashMap;")?;
         }
-        writeln!(w, "use quick_protobuf::{{MessageWrite, BytesReader, Writer, Result}};")?;
+        writeln!(w, "use quick_protobuf::{{MessageRead, MessageWrite, BytesReader, Writer, Result}};")?;
         writeln!(w, "use quick_protobuf::sizeofs::*;")?;
         Ok(())
     }
@@ -1433,7 +1433,7 @@ fn update_mod_file(path: &Path) -> Result<()> {
     let mut file = path.to_path_buf();
     use std::fs::OpenOptions;
     use std::io::prelude::*;
-    
+
     let name = file.file_stem().unwrap().to_string_lossy().to_string();
     file.pop();
     file.push("mod.rs");

--- a/examples/codegen/a/b.rs
+++ b/examples/codegen/a/b.rs
@@ -10,7 +10,7 @@
 
 
 use std::io::Write;
-use quick_protobuf::{MessageWrite, BytesReader, Writer, Result};
+use quick_protobuf::{MessageRead, MessageWrite, BytesReader, Writer, Result};
 use quick_protobuf::sizeofs::*;
 use super::super::*;
 
@@ -19,8 +19,8 @@ pub struct ImportedMessage {
     pub i: Option<bool>,
 }
 
-impl ImportedMessage {
-    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for ImportedMessage {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {

--- a/examples/codegen/data_types_unit.rs
+++ b/examples/codegen/data_types_unit.rs
@@ -9,7 +9,7 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 
-use quick_protobuf::{BytesReader, Result, MessageWrite};
+use quick_protobuf::{BytesReader, Result, MessageRead, MessageWrite};
 use super::*;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -35,8 +35,8 @@ impl From<i32> for test {
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct unit_message { }
 
-impl unit_message {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for unit_message {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }

--- a/examples/codegen_example.rs
+++ b/examples/codegen_example.rs
@@ -66,7 +66,7 @@ fn main() {
     // to directly use a `BytesWriter`.
     let read_message = {
         let mut reader = BytesReader::from_bytes(&out);
-        reader.read_message(&out, FooMessage::from_reader).expect("Cannot read message")
+        reader.read_message::<FooMessage>(&out).expect("Cannot read message")
     };
     assert_eq!(message, read_message);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,6 @@ pub mod writer;
 pub mod sizeofs;
 
 pub use errors::Result;
-pub use message::{MessageWrite};
+pub use message::{MessageWrite, MessageRead};
 pub use reader::{Reader, BytesReader};
 pub use writer::Writer;

--- a/src/message.rs
+++ b/src/message.rs
@@ -8,6 +8,7 @@ use std::fs::File;
 
 use errors::Result;
 use writer::Writer;
+use reader::BytesReader;
 
 /// A trait to handle deserialization based on parsed `Field`s
 pub trait MessageWrite: Sized {
@@ -28,4 +29,11 @@ pub trait MessageWrite: Sized {
         let mut writer = Writer::new(file);
         self.write_message(&mut writer)
     }
+}
+
+/// A trait to handle deserialization from protocol buffers.
+pub trait MessageRead<'a>: Sized {
+    /// Constructs an instance of `Self` by reading from the given bytes
+    /// via the given reader.
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self>;
 }

--- a/tests/issue69/person.rs
+++ b/tests/issue69/person.rs
@@ -10,7 +10,7 @@
 
 
 use std::io::Write;
-use quick_protobuf::{MessageWrite, BytesReader, Writer, Result};
+use quick_protobuf::{MessageRead, MessageWrite, BytesReader, Writer, Result};
 use quick_protobuf::sizeofs::*;
 use super::*;
 
@@ -41,8 +41,8 @@ pub struct Address {
     pub city: Option<City>,
 }
 
-impl Address {
-    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for Address {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
@@ -72,12 +72,12 @@ pub struct Person {
     pub address: Option<Address>,
 }
 
-impl Person {
-    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for Person {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
-                Ok(18) => msg.address = Some(r.read_message(bytes, Address::from_reader)?),
+                Ok(18) => msg.address = Some(r.read_message::<Address>(bytes)?),
                 Ok(t) => { r.read_unknown(bytes, t)?; }
                 Err(e) => return Err(e),
             }

--- a/tests/rust_protobuf/test_utils.rs
+++ b/tests/rust_protobuf/test_utils.rs
@@ -36,7 +36,7 @@ macro_rules! test_serialize_deserialize_length_delimited {
             writer.write_message($msg).unwrap();
         }
         let mut reader = BytesReader::from_bytes(&serialized);
-        let parsed = reader.read_message(&serialized, $name::from_reader).unwrap();
+        let parsed: $name = reader.read_message(&serialized).unwrap();
         assert!($msg.eq(&parsed));
     }
 }

--- a/tests/rust_protobuf/v2/basic.rs
+++ b/tests/rust_protobuf/v2/basic.rs
@@ -11,7 +11,7 @@
 
 use std::io::Write;
 use std::borrow::Cow;
-use quick_protobuf::{MessageWrite, BytesReader, Writer, Result};
+use quick_protobuf::{MessageRead, MessageWrite, BytesReader, Writer, Result};
 use quick_protobuf::sizeofs::*;
 use super::*;
 
@@ -44,8 +44,8 @@ pub struct Test1 {
     pub a: i32,
 }
 
-impl Test1 {
-    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for Test1 {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
@@ -75,8 +75,8 @@ pub struct Test2<'a> {
     pub b: Cow<'a, str>,
 }
 
-impl<'a> Test2<'a> {
-    pub fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for Test2<'a> {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
@@ -106,12 +106,12 @@ pub struct Test3 {
     pub c: basic::Test1,
 }
 
-impl Test3 {
-    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for Test3 {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
-                Ok(26) => msg.c = r.read_message(bytes, basic::Test1::from_reader)?,
+                Ok(26) => msg.c = r.read_message::<basic::Test1>(bytes)?,
                 Ok(t) => { r.read_unknown(bytes, t)?; }
                 Err(e) => return Err(e),
             }
@@ -137,8 +137,8 @@ pub struct Test4 {
     pub d: Vec<i32>,
 }
 
-impl Test4 {
-    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for Test4 {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
@@ -169,8 +169,8 @@ pub struct TestPackedUnpacked {
     pub packed: Vec<i32>,
 }
 
-impl TestPackedUnpacked {
-    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestPackedUnpacked {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
@@ -203,8 +203,8 @@ pub struct TestEmpty {
     pub foo: Option<i32>,
 }
 
-impl TestEmpty {
-    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestEmpty {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
@@ -234,8 +234,8 @@ pub struct TestUnknownFields {
     pub a: i32,
 }
 
-impl TestUnknownFields {
-    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestUnknownFields {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
@@ -266,13 +266,13 @@ pub struct TestSelfReference {
     pub r2: Option<Box<basic::TestSelfReference>>,
 }
 
-impl TestSelfReference {
-    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestSelfReference {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
-                Ok(10) => msg.r1 = Some(Box::new(r.read_message(bytes, basic::TestSelfReference::from_reader)?)),
-                Ok(18) => msg.r2 = Some(Box::new(r.read_message(bytes, basic::TestSelfReference::from_reader)?)),
+                Ok(10) => msg.r1 = Some(Box::new(r.read_message::<basic::TestSelfReference>(bytes)?)),
+                Ok(18) => msg.r2 = Some(Box::new(r.read_message::<basic::TestSelfReference>(bytes)?)),
                 Ok(t) => { r.read_unknown(bytes, t)?; }
                 Err(e) => return Err(e),
             }
@@ -300,8 +300,8 @@ pub struct TestDefaultInstanceField<'a> {
     pub s: Option<Cow<'a, str>>,
 }
 
-impl<'a> TestDefaultInstanceField<'a> {
-    pub fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestDefaultInstanceField<'a> {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
@@ -331,12 +331,12 @@ pub struct TestDefaultInstance<'a> {
     pub field: Option<basic::TestDefaultInstanceField<'a>>,
 }
 
-impl<'a> TestDefaultInstance<'a> {
-    pub fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestDefaultInstance<'a> {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
-                Ok(10) => msg.field = Some(r.read_message(bytes, basic::TestDefaultInstanceField::from_reader)?),
+                Ok(10) => msg.field = Some(r.read_message::<basic::TestDefaultInstanceField>(bytes)?),
                 Ok(t) => { r.read_unknown(bytes, t)?; }
                 Err(e) => return Err(e),
             }
@@ -362,8 +362,8 @@ pub struct TestDescriptor {
     pub stuff: Option<i32>,
 }
 
-impl TestDescriptor {
-    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestDescriptor {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
@@ -408,8 +408,8 @@ pub struct TestTypesSingular<'a> {
     pub enum_field: Option<basic::TestEnumDescriptor>,
 }
 
-impl<'a> TestTypesSingular<'a> {
-    pub fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestTypesSingular<'a> {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
@@ -499,8 +499,8 @@ pub struct TestTypesRepeated<'a> {
     pub enum_field: Vec<basic::TestEnumDescriptor>,
 }
 
-impl<'a> TestTypesRepeated<'a> {
-    pub fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestTypesRepeated<'a> {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
@@ -590,8 +590,8 @@ pub struct TestTypesRepeatedPacked<'a> {
     pub enum_field: Vec<basic::TestEnumDescriptor>,
 }
 
-impl<'a> TestTypesRepeatedPacked<'a> {
-    pub fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestTypesRepeatedPacked<'a> {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
@@ -664,8 +664,8 @@ impl<'a> MessageWrite for TestTypesRepeatedPacked<'a> {
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct TestInvalidTag { }
 
-impl TestInvalidTag {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestInvalidTag {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }
@@ -678,8 +678,8 @@ pub struct TestTruncated<'a> {
     pub ints: Cow<'a, [u32]>,
 }
 
-impl<'a> TestTruncated<'a> {
-    pub fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestTruncated<'a> {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
@@ -710,8 +710,8 @@ pub struct TestBugSint {
     pub s64: Option<i64>,
 }
 
-impl TestBugSint {
-    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestBugSint {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {

--- a/tests/rust_protobuf/v2/foo/bar.rs
+++ b/tests/rust_protobuf/v2/foo/bar.rs
@@ -10,7 +10,7 @@
 
 
 use std::io::Write;
-use quick_protobuf::{MessageWrite, BytesReader, Writer, Result};
+use quick_protobuf::{MessageRead, MessageWrite, BytesReader, Writer, Result};
 use quick_protobuf::sizeofs::*;
 use super::super::*;
 
@@ -20,12 +20,12 @@ pub struct ContainsImportedNested {
     pub e: Option<foo::baz::mod_ContainerForNested::NestedEnum>,
 }
 
-impl ContainsImportedNested {
-    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for ContainsImportedNested {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
-                Ok(10) => msg.m = Some(r.read_message(bytes, foo::baz::mod_ContainerForNested::NestedMessage::from_reader)?),
+                Ok(10) => msg.m = Some(r.read_message::<foo::baz::mod_ContainerForNested::NestedMessage>(bytes)?),
                 Ok(16) => msg.e = Some(r.read_enum(bytes)?),
                 Ok(t) => { r.read_unknown(bytes, t)?; }
                 Err(e) => return Err(e),

--- a/tests/rust_protobuf/v2/foo/baz.rs
+++ b/tests/rust_protobuf/v2/foo/baz.rs
@@ -9,14 +9,14 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 
-use quick_protobuf::{BytesReader, Result, MessageWrite};
+use quick_protobuf::{BytesReader, Result, MessageRead, MessageWrite};
 use super::super::*;
 
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct ContainerForNested { }
 
-impl ContainerForNested {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for ContainerForNested {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }
@@ -31,8 +31,8 @@ use super::*;
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct NestedMessage { }
 
-impl NestedMessage {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for NestedMessage {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }

--- a/tests/rust_protobuf/v2/nonunique_1.rs
+++ b/tests/rust_protobuf/v2/nonunique_1.rs
@@ -9,14 +9,14 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 
-use quick_protobuf::{BytesReader, Result, MessageWrite};
+use quick_protobuf::{BytesReader, Result, MessageRead, MessageWrite};
 use super::*;
 
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct Nonunique { }
 
-impl Nonunique {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for Nonunique {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }

--- a/tests/rust_protobuf/v2/nonunique_2.rs
+++ b/tests/rust_protobuf/v2/nonunique_2.rs
@@ -9,14 +9,14 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 
-use quick_protobuf::{BytesReader, Result, MessageWrite};
+use quick_protobuf::{BytesReader, Result, MessageRead, MessageWrite};
 use super::*;
 
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct Nonunique { }
 
-impl Nonunique {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for Nonunique {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }

--- a/tests/rust_protobuf/v2/special.rs
+++ b/tests/rust_protobuf/v2/special.rs
@@ -9,14 +9,14 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 
-use quick_protobuf::{BytesReader, Result, MessageWrite};
+use quick_protobuf::{BytesReader, Result, MessageRead, MessageWrite};
 use super::*;
 
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct Outer { }
 
-impl Outer {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for Outer {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }

--- a/tests/rust_protobuf/v2/struct_pb.rs
+++ b/tests/rust_protobuf/v2/struct_pb.rs
@@ -9,14 +9,14 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 
-use quick_protobuf::{BytesReader, Result, MessageWrite};
+use quick_protobuf::{BytesReader, Result, MessageRead, MessageWrite};
 use super::*;
 
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct KeepTheFile { }
 
-impl KeepTheFile {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for KeepTheFile {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }

--- a/tests/rust_protobuf/v2/test_default_values.rs
+++ b/tests/rust_protobuf/v2/test_default_values.rs
@@ -11,7 +11,7 @@
 
 use std::io::Write;
 use std::borrow::Cow;
-use quick_protobuf::{MessageWrite, BytesReader, Writer, Result};
+use quick_protobuf::{MessageRead, MessageWrite, BytesReader, Writer, Result};
 use quick_protobuf::sizeofs::*;
 use super::*;
 
@@ -60,8 +60,8 @@ pub struct TestDefaultValues<'a> {
     pub enum_field_without_default: Option<test_default_values::EnumForDefaultValue>,
 }
 
-impl<'a> TestDefaultValues<'a> {
-    pub fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestDefaultValues<'a> {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = TestDefaultValues {
             double_field: 1f64,
             float_field: 2f32,
@@ -162,8 +162,8 @@ pub struct TestExtremeDefaultValues {
     pub nan_float: f32,
 }
 
-impl TestExtremeDefaultValues {
-    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestExtremeDefaultValues {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = TestExtremeDefaultValues {
             inf_double: ::std::f64::INFINITY,
             neg_inf_double: ::std::f64::NEG_INFINITY,

--- a/tests/rust_protobuf/v2/test_enum_values_pb.rs
+++ b/tests/rust_protobuf/v2/test_enum_values_pb.rs
@@ -9,7 +9,7 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 
-use quick_protobuf::{BytesReader, Result, MessageWrite};
+use quick_protobuf::{BytesReader, Result, MessageRead, MessageWrite};
 use super::*;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/tests/rust_protobuf/v2/test_ident_pb.rs
+++ b/tests/rust_protobuf/v2/test_ident_pb.rs
@@ -11,15 +11,15 @@
 
 use std::io::Write;
 use std::borrow::Cow;
-use quick_protobuf::{MessageWrite, BytesReader, Writer, Result};
+use quick_protobuf::{MessageRead, MessageWrite, BytesReader, Writer, Result};
 use quick_protobuf::sizeofs::*;
 use super::*;
 
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct Vec_pb { }
 
-impl Vec_pb {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for Vec_pb {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }
@@ -30,8 +30,8 @@ impl MessageWrite for Vec_pb { }
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct String_pb { }
 
-impl String_pb {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for String_pb {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }
@@ -42,8 +42,8 @@ impl MessageWrite for String_pb { }
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct Option_pb { }
 
-impl Option_pb {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for Option_pb {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }
@@ -54,8 +54,8 @@ impl MessageWrite for Option_pb { }
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct None_pb { }
 
-impl None_pb {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for None_pb {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }
@@ -66,8 +66,8 @@ impl MessageWrite for None_pb { }
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct Some_pb { }
 
-impl Some_pb {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for Some_pb {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }
@@ -78,8 +78,8 @@ impl MessageWrite for Some_pb { }
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct Message { }
 
-impl Message {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for Message {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }
@@ -94,8 +94,8 @@ pub struct TestType<'a> {
     pub type_pb: mod_TestType::OneOftype_pb<'a>,
 }
 
-impl<'a> TestType<'a> {
-    pub fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestType<'a> {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {

--- a/tests/rust_protobuf/v2/test_import_nested_imported_pb.rs
+++ b/tests/rust_protobuf/v2/test_import_nested_imported_pb.rs
@@ -9,14 +9,14 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 
-use quick_protobuf::{BytesReader, Result, MessageWrite};
+use quick_protobuf::{BytesReader, Result, MessageRead, MessageWrite};
 use super::*;
 
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct ContainerForNested { }
 
-impl ContainerForNested {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for ContainerForNested {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }
@@ -31,8 +31,8 @@ use super::*;
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct NestedMessage { }
 
-impl NestedMessage {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for NestedMessage {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }

--- a/tests/rust_protobuf/v2/test_import_nested_pb.rs
+++ b/tests/rust_protobuf/v2/test_import_nested_pb.rs
@@ -10,7 +10,7 @@
 
 
 use std::io::Write;
-use quick_protobuf::{MessageWrite, BytesReader, Writer, Result};
+use quick_protobuf::{MessageRead, MessageWrite, BytesReader, Writer, Result};
 use quick_protobuf::sizeofs::*;
 use super::*;
 
@@ -20,12 +20,12 @@ pub struct ContainsImportedNested {
     pub e: Option<test_import_nested_imported_pb::mod_ContainerForNested::NestedEnum>,
 }
 
-impl ContainsImportedNested {
-    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for ContainsImportedNested {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
-                Ok(10) => msg.m = Some(r.read_message(bytes, test_import_nested_imported_pb::mod_ContainerForNested::NestedMessage::from_reader)?),
+                Ok(10) => msg.m = Some(r.read_message::<test_import_nested_imported_pb::mod_ContainerForNested::NestedMessage>(bytes)?),
                 Ok(16) => msg.e = Some(r.read_enum(bytes)?),
                 Ok(t) => { r.read_unknown(bytes, t)?; }
                 Err(e) => return Err(e),

--- a/tests/rust_protobuf/v2/test_import_nonunique_pb.rs
+++ b/tests/rust_protobuf/v2/test_import_nonunique_pb.rs
@@ -10,7 +10,7 @@
 
 
 use std::io::Write;
-use quick_protobuf::{MessageWrite, BytesReader, Writer, Result};
+use quick_protobuf::{MessageRead, MessageWrite, BytesReader, Writer, Result};
 use quick_protobuf::sizeofs::*;
 use super::*;
 
@@ -20,13 +20,13 @@ pub struct TestImportNonunque {
     pub n2: Option<nonunique_2::Nonunique>,
 }
 
-impl TestImportNonunque {
-    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestImportNonunque {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
-                Ok(10) => msg.n1 = Some(r.read_message(bytes, nonunique_1::Nonunique::from_reader)?),
-                Ok(18) => msg.n2 = Some(r.read_message(bytes, nonunique_2::Nonunique::from_reader)?),
+                Ok(10) => msg.n1 = Some(r.read_message::<nonunique_1::Nonunique>(bytes)?),
+                Ok(18) => msg.n2 = Some(r.read_message::<nonunique_2::Nonunique>(bytes)?),
                 Ok(t) => { r.read_unknown(bytes, t)?; }
                 Err(e) => return Err(e),
             }

--- a/tests/rust_protobuf/v2/test_import_root_imported_pb.rs
+++ b/tests/rust_protobuf/v2/test_import_root_imported_pb.rs
@@ -9,7 +9,7 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 
-use quick_protobuf::{BytesReader, Result, MessageWrite};
+use quick_protobuf::{BytesReader, Result, MessageRead, MessageWrite};
 use super::*;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -35,8 +35,8 @@ impl From<i32> for ImportedEnum {
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct ImportedMessage { }
 
-impl ImportedMessage {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for ImportedMessage {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }

--- a/tests/rust_protobuf/v2/test_import_root_pb.rs
+++ b/tests/rust_protobuf/v2/test_import_root_pb.rs
@@ -10,7 +10,7 @@
 
 
 use std::io::Write;
-use quick_protobuf::{MessageWrite, BytesReader, Writer, Result};
+use quick_protobuf::{MessageRead, MessageWrite, BytesReader, Writer, Result};
 use quick_protobuf::sizeofs::*;
 use super::*;
 
@@ -20,12 +20,12 @@ pub struct ContainsImported {
     pub imported_enum: Option<test_import_root_imported_pb::ImportedEnum>,
 }
 
-impl ContainsImported {
-    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for ContainsImported {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
-                Ok(10) => msg.imported_message = Some(r.read_message(bytes, test_import_root_imported_pb::ImportedMessage::from_reader)?),
+                Ok(10) => msg.imported_message = Some(r.read_message::<test_import_root_imported_pb::ImportedMessage>(bytes)?),
                 Ok(16) => msg.imported_enum = Some(r.read_enum(bytes)?),
                 Ok(t) => { r.read_unknown(bytes, t)?; }
                 Err(e) => return Err(e),

--- a/tests/rust_protobuf/v2/test_lite_runtime.rs
+++ b/tests/rust_protobuf/v2/test_lite_runtime.rs
@@ -10,7 +10,7 @@
 
 
 use std::io::Write;
-use quick_protobuf::{MessageWrite, BytesReader, Writer, Result};
+use quick_protobuf::{MessageRead, MessageWrite, BytesReader, Writer, Result};
 use quick_protobuf::sizeofs::*;
 use super::*;
 
@@ -41,8 +41,8 @@ pub struct TestLiteRuntime {
     pub v: Option<i32>,
 }
 
-impl TestLiteRuntime {
-    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestLiteRuntime {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {

--- a/tests/rust_protobuf/v2/test_nonunique_enum_pb.rs
+++ b/tests/rust_protobuf/v2/test_nonunique_enum_pb.rs
@@ -9,14 +9,14 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 
-use quick_protobuf::{BytesReader, Result, MessageWrite};
+use quick_protobuf::{BytesReader, Result, MessageRead, MessageWrite};
 use super::*;
 
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct MessageA { }
 
-impl MessageA {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for MessageA {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }
@@ -52,8 +52,8 @@ impl From<i32> for EnumA {
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct MessageB { }
 
-impl MessageB {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for MessageB {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }

--- a/tests/rust_protobuf/v2/test_required.rs
+++ b/tests/rust_protobuf/v2/test_required.rs
@@ -10,7 +10,7 @@
 
 
 use std::io::Write;
-use quick_protobuf::{MessageWrite, BytesReader, Writer, Result};
+use quick_protobuf::{MessageRead, MessageWrite, BytesReader, Writer, Result};
 use quick_protobuf::sizeofs::*;
 use super::*;
 
@@ -19,8 +19,8 @@ pub struct TestRequired {
     pub b: bool,
 }
 
-impl TestRequired {
-    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestRequired {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {

--- a/tests/rust_protobuf/v2/test_root_pb.rs
+++ b/tests/rust_protobuf/v2/test_root_pb.rs
@@ -10,7 +10,7 @@
 
 
 use std::io::Write;
-use quick_protobuf::{MessageWrite, BytesReader, Writer, Result};
+use quick_protobuf::{MessageRead, MessageWrite, BytesReader, Writer, Result};
 use quick_protobuf::sizeofs::*;
 use super::*;
 

--- a/tests/rust_protobuf/v2/test_sanitize_file_name_pb.rs
+++ b/tests/rust_protobuf/v2/test_sanitize_file_name_pb.rs
@@ -9,14 +9,14 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 
-use quick_protobuf::{BytesReader, Result, MessageWrite};
+use quick_protobuf::{BytesReader, Result, MessageRead, MessageWrite};
 use super::*;
 
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct FooBar { }
 
-impl FooBar {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for FooBar {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }

--- a/tests/rust_protobuf/v3/test_ident_pb.rs
+++ b/tests/rust_protobuf/v3/test_ident_pb.rs
@@ -11,15 +11,15 @@
 
 use std::io::Write;
 use std::borrow::Cow;
-use quick_protobuf::{MessageWrite, BytesReader, Writer, Result};
+use quick_protobuf::{MessageRead, MessageWrite, BytesReader, Writer, Result};
 use quick_protobuf::sizeofs::*;
 use super::*;
 
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct Vec_pb { }
 
-impl Vec_pb {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for Vec_pb {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }
@@ -30,8 +30,8 @@ impl MessageWrite for Vec_pb { }
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct String_pb { }
 
-impl String_pb {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for String_pb {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }
@@ -42,8 +42,8 @@ impl MessageWrite for String_pb { }
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct Option_pb { }
 
-impl Option_pb {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for Option_pb {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }
@@ -54,8 +54,8 @@ impl MessageWrite for Option_pb { }
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct None_pb { }
 
-impl None_pb {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for None_pb {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }
@@ -66,8 +66,8 @@ impl MessageWrite for None_pb { }
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct Some_pb { }
 
-impl Some_pb {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for Some_pb {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }
@@ -78,8 +78,8 @@ impl MessageWrite for Some_pb { }
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct Message { }
 
-impl Message {
-    pub fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for Message {
+    fn from_reader(r: &mut BytesReader, _: &[u8]) -> Result<Self> {
         r.read_to_end();
         Ok(Self::default())
     }
@@ -94,8 +94,8 @@ pub struct TestType<'a> {
     pub type_pb: mod_TestType::OneOftype_pb<'a>,
 }
 
-impl<'a> TestType<'a> {
-    pub fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestType<'a> {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {

--- a/tests/rust_protobuf/v3/test_oneof_pb.rs
+++ b/tests/rust_protobuf/v3/test_oneof_pb.rs
@@ -11,7 +11,7 @@
 
 use std::io::Write;
 use std::borrow::Cow;
-use quick_protobuf::{MessageWrite, BytesReader, Writer, Result};
+use quick_protobuf::{MessageRead, MessageWrite, BytesReader, Writer, Result};
 use quick_protobuf::sizeofs::*;
 use super::*;
 
@@ -42,8 +42,8 @@ pub struct MessageForOneof {
     pub f: Option<i32>,
 }
 
-impl MessageForOneof {
-    pub fn from_reader(r: &mut BytesReader, bytes: &[u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for MessageForOneof {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
@@ -74,8 +74,8 @@ pub struct TestOneof<'a> {
     pub one: mod_TestOneof::OneOfone<'a>,
 }
 
-impl<'a> TestOneof<'a> {
-    pub fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
+impl<'a> MessageRead<'a> for TestOneof<'a> {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
         let mut msg = Self::default();
         while !r.is_eof() {
             match r.next_tag(bytes) {
@@ -96,7 +96,7 @@ impl<'a> TestOneof<'a> {
                 Ok(114) => msg.one = mod_TestOneof::OneOfone::string_field(r.read_string(bytes).map(Cow::Borrowed)?),
                 Ok(122) => msg.one = mod_TestOneof::OneOfone::bytes_field(r.read_bytes(bytes).map(Cow::Borrowed)?),
                 Ok(128) => msg.one = mod_TestOneof::OneOfone::enum_field(r.read_enum(bytes)?),
-                Ok(138) => msg.one = mod_TestOneof::OneOfone::message_field(r.read_message(bytes, MessageForOneof::from_reader)?),
+                Ok(138) => msg.one = mod_TestOneof::OneOfone::message_field(r.read_message::<MessageForOneof>(bytes)?),
                 Ok(t) => { r.read_unknown(bytes, t)?; }
                 Err(e) => return Err(e),
             }


### PR DESCRIPTION
This has some advantages with clarity in the type system, but the disadvantage of disallowing custom 'read' functions passed to `BytesReader::read_message`.

This also adds a need for a turbofish in some cases of `reader.read_mesage::<TypeName>(...)`.

Really liking the library so far, and hoping this is an overall positive change!

Closes #78.