### PR TITLE
Explicitly mention the usage of pb-rs as a crate

### DIFF
--- a/codegen/README.md
+++ b/codegen/README.md
@@ -7,3 +7,24 @@ A simple converter from .proto files into rust quick-protobuf compatible modules
 ```
 pb-rs <file.proto>
 ```
+
+pb-rs can also be used as a crate (for example in your cargo build scripts).
+
+```rust
+extern crate pb_rs;
+
+use std::path::PathBuf;
+use pb_rs::types::{Config, FileDescriptor};
+
+fn main() {
+    let config = Config {
+        in_file: PathBuf::from("protos/Hello.proto"),
+        out_file: PathBuf::from("src/hello.rs"),
+        single_module: false,
+        import_search_path: vec![PathBuf::from("protos")],
+        no_output: false,
+    };
+
+    FileDescriptor::write_proto(&config).unwrap();
+}
+```


### PR DESCRIPTION
When choosing what crate to use for protobuf support, I hesitated to use quick-protobuf as I believed pb-rs was only usable through the command line. When I discovered that it is actually usable as a crate, I had already started to use another crate, that isn't as good as quick-protobuf.

To avoid this to happen again, this PR explicitly mentions in the README.md for pb-rs that it is usable as a crate, alongside a simple example.