### PR TITLE
Allow to advance arbitrary bytes in BytesReader

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -7,15 +7,15 @@
 //!
 //! It is advised, for convenience to directly work with a `Reader`.
 
+use std::fs::File;
 use std::io::{self, Read};
 use std::path::Path;
-use std::fs::File;
 
 use errors::{Error, Result};
 use message::MessageRead;
 
-use byteorder::LittleEndian as LE;
 use byteorder::ByteOrder;
+use byteorder::LittleEndian as LE;
 
 const WIRE_TYPE_VARINT: u8 = 0;
 const WIRE_TYPE_FIXED64: u8 = 1;
@@ -453,7 +453,14 @@ impl BytesReader {
         self.start == self.end
     }
 
-    /// Advance inner cursor to the end
+    /// Advances inner cursor by length bytes without overflow, and returns the amount of bytes actually advanced
+    pub fn advance(&mut self, length: usize) -> usize {
+        let length = length.min(self.len());
+        self.start += length;
+        length
+    }
+
+    /// Advances inner cursor to the end
     pub fn read_to_end(&mut self) {
         self.start = self.end;
     }

--- a/tests/write_read.rs
+++ b/tests/write_read.rs
@@ -38,6 +38,18 @@ write_read_primitive!(wr_float, read_float, write_float, 5.8);
 write_read_primitive!(wr_double, read_double, write_double, 5.8);
 
 #[test]
+fn advance() {
+    let buf: Vec<u8> = vec![0xDE, 0xAD, 0x00, 0x60, 0x0D, 0xCA, 0xFE];
+    let mut r = BytesReader::from_bytes(&buf);
+    let advanced = r.advance(2);
+    assert_eq!(advanced, 2);
+    assert_eq!(0, r.read_uint32(&buf).unwrap());
+    let advanced = r.advance(18);
+    assert_eq!(advanced, 4);
+    assert!(r.is_eof());
+}
+
+#[test]
 fn wr_bytes() {
     let v = b"test_write_read";
     let mut buf = Vec::new();


### PR DESCRIPTION
I am working on a network protocol using protobuf, and the buffers I get are protocol buffers with a 2 bytes packet ID header. However, there seems to be no good way to prevent the reader from taking those two bytes into the decoding process.

This PR provides a way to skip an arbitrary amount of bytes when using BytesReader, so that messages with additional data in the same buffer can be read more easily.