### PR TITLE
Make byte-specific utilities available in BytesReader

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -88,8 +88,9 @@ impl BytesReader {
         self.read_varint32(bytes)
     }
 
+    /// Reads the next byte
     #[inline(always)]
-    fn read_u8(&mut self, bytes: &[u8]) -> Result<u8> {
+    pub fn read_u8(&mut self, bytes: &[u8]) -> Result<u8> {
         let b = bytes.get(self.start).ok_or_else::<Error, _>(|| {
             Error::Io(io::Error::new(
                 io::ErrorKind::UnexpectedEof,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -62,6 +62,11 @@ impl<W: Write> Writer<W> {
         Writer { inner: w }
     }
 
+    /// Writes a byte which is NOT internally coded as a `varint`
+    pub fn write_u8(&mut self, byte: u8) -> Result<()> {
+        self.inner.write_u8(byte).map_err(|e| e.into())
+    }
+
     /// Writes a `varint` (compacted `u64`)
     pub fn write_varint(&mut self, mut v: u64) -> Result<()> {
         while v > 0x7F {

--- a/tests/write_read.rs
+++ b/tests/write_read.rs
@@ -25,6 +25,7 @@ macro_rules! write_read_primitive {
     };
 }
 
+write_read_primitive!(wr_u8, read_u8, write_u8);
 write_read_primitive!(wr_int32, read_int32, write_int32);
 write_read_primitive!(wr_int64, read_int64, write_int64);
 write_read_primitive!(wr_uint32, read_uint32, write_uint32);


### PR DESCRIPTION
See #105 for motivations.

This PR makes `read_u8` public in the BytesReader, and creates a `write_u8` method in the writer.
This will allow to write multiple messages and separate them in a single buffer with a single writer.