### PR TITLE
Add possibility to read message with speciefied length

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -311,18 +311,19 @@ impl BytesReader {
         self.read_int32(bytes).map(|e| e.into())
     }
 
+    /// First reads a varint and use it as size to read a generic object
     #[inline(always)]
-    fn read_len<'a, M, F>(&mut self, bytes: &'a [u8], read: F) -> Result<M>
+    fn read_len_varint<'a, M, F>(&mut self, bytes: &'a [u8], read: F) -> Result<M>
     where
         F: FnMut(&mut BytesReader, &'a [u8]) -> Result<M>,
     {
         let len = self.read_varint32(bytes)? as usize;
-        self.read_len_size(bytes, read, len)
+        self.read_len(bytes, read, len)
     }
 
-
+    /// Reads a certain number of bytes specified by len
     #[inline(always)]
-    fn read_len_size<'a, M, F>(&mut self, bytes: &'a [u8], mut read: F, len: usize) -> Result<M>
+    fn read_len<'a, M, F>(&mut self, bytes: &'a [u8], mut read: F, len: usize) -> Result<M>
         where
             F: FnMut(&mut BytesReader, &'a [u8]) -> Result<M>,
     {
@@ -337,13 +338,13 @@ impl BytesReader {
     /// Reads bytes (Vec<u8>)
     #[inline]
     pub fn read_bytes<'a>(&mut self, bytes: &'a [u8]) -> Result<&'a [u8]> {
-        self.read_len(bytes, |r, b| Ok(&b[r.start..r.end]))
+        self.read_len_varint(bytes, |r, b| Ok(&b[r.start..r.end]))
     }
 
     /// Reads string (String)
     #[inline]
     pub fn read_string<'a>(&mut self, bytes: &'a [u8]) -> Result<&'a str> {
-        self.read_len(bytes, |r, b| {
+        self.read_len_varint(bytes, |r, b| {
             ::std::str::from_utf8(&b[r.start..r.end]).map_err(|e| e.into())
         })
     }
@@ -357,7 +358,7 @@ impl BytesReader {
     where
         F: FnMut(&mut BytesReader, &'a [u8]) -> Result<M>,
     {
-        self.read_len(bytes, |r, b| {
+        self.read_len_varint(bytes, |r, b| {
             let mut v = Vec::new();
             while !r.is_eof() {
                 v.push(read(r, b)?);
@@ -391,21 +392,26 @@ impl BytesReader {
     }
 
     /// Reads a nested message
+    ///
+    /// First reads a varint and interprets it as the length of the message
     #[inline]
     pub fn read_message<'a, M>(&mut self, bytes: &'a [u8]) -> Result<M>
     where
         M: MessageRead<'a>,
     {
-        self.read_len(bytes, M::from_reader)
+        self.read_len_varint(bytes, M::from_reader)
     }
 
     /// Reads a nested message
+    ///
+    /// Reads just the message and does not try to read it's size first.
+    ///  * 'len' - The length of the message to be read.
     #[inline]
-    pub fn read_message_size<'a, M>(&mut self, bytes: &'a [u8], len: usize) -> Result<M>
+    pub fn read_message_by_len<'a, M>(&mut self, bytes: &'a [u8], len: usize) -> Result<M>
         where
             M: MessageRead<'a>,
     {
-        self.read_len_size(bytes, M::from_reader, len)
+        self.read_len(bytes, M::from_reader, len)
     }
 
     /// Reads a map item: (key, value)
@@ -422,7 +428,7 @@ impl BytesReader {
         K: ::std::fmt::Debug + Default,
         V: ::std::fmt::Debug + Default,
     {
-        self.read_len(bytes, |r, bytes| {
+        self.read_len_varint(bytes, |r, bytes| {
             let mut k = K::default();
             let mut v = V::default();
             while !r.is_eof() {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -326,7 +326,6 @@ impl BytesReader {
         where
             F: FnMut(&mut BytesReader, &'a [u8]) -> Result<M>,
     {
-        println!("{}", len);
         let cur_end = self.end;
         self.end = self.start + len;
         let v = read(self, bytes)?;


### PR DESCRIPTION
As you can read in https://developers.google.com/protocol-buffers/docs/techniques
the protobuf protocol does not specify the format how the length of a message
is stated. If you communicate with an entity which does not encode it's message
length in varints you are not able to read them. Therfore this fix should enable
you to read your own format of message size and read the message of specified
length.

This should fix #108 

If you merge this it would be nice if you can publish it soon because I am relying on this fix and currently depending on a local Version of quick-protobuf. Thank you.