### PR TITLE
Make distinction between Message, Enum and MessageOrEnum

### DIFF
--- a/pb-rs/src/parser.rs
+++ b/pb-rs/src/parser.rs
@@ -508,9 +508,12 @@ mod test {
         if let ::nom::IResult::Done(_, mess) = mess {
             assert_eq!(1, mess.fields.len());
             match mess.fields[0].typ {
-                FieldType::Map(ref f) => match &**f {
-                    &(FieldType::String_, FieldType::Int32) => (),
-                    ref f => panic!("Expecting Map<String, Int32> found {:?}", f),
+                FieldType::Map(ref key, ref value) => match (&**key, &**value) {
+                    (&FieldType::String_, &FieldType::Int32) => (),
+                    _ => panic!(
+                        "Expecting Map<String, Int32> found Map<{:?}, {:?}>",
+                        key, value
+                    ),
                 },
                 ref f => panic!("Expecting map, got {:?}", f),
             }

--- a/pb-rs/src/parser.rs
+++ b/pb-rs/src/parser.rs
@@ -158,8 +158,8 @@ named!(
             tag!("bytes") => { |_| FieldType::Bytes } |
             tag!("float") => { |_| FieldType::Float } |
             tag!("double") => { |_| FieldType::Double } |
-            map_field => { |(k, v)| FieldType::Map(Box::new((k, v))) } |
-            word => { |w| FieldType::Message(w) })
+            map_field => { |(k, v)| FieldType::Map(Box::new(k), Box::new(v)) } |
+            word => { |w| FieldType::MessageOrEnum(w) })
 );
 
 named!(

--- a/pb-rs/src/types.rs
+++ b/pb-rs/src/types.rs
@@ -975,6 +975,20 @@ impl Message {
     ///
     /// If none is found, then it is an enum
     fn set_enums(&mut self, desc: &FileDescriptor) {
+        // if there is a default value, then it is an enum
+        for f in self
+            .fields
+            .iter_mut()
+            .chain(self.oneofs.iter_mut().flat_map(|o| o.fields.iter_mut()))
+        {
+            if f.default.is_some() {
+                if let FieldType::MessageOrEnum(m) = f.typ.clone() {
+                    f.typ = FieldType::Enum(m);
+                }
+            }
+        }
+
+        // else if we find a message, then it is a message, else an enum
         for typ in self
             .fields
             .iter_mut()

--- a/pb-rs/src/types.rs
+++ b/pb-rs/src/types.rs
@@ -61,9 +61,10 @@ pub enum FieldType {
 impl FieldType {
     pub fn is_primitive(&self) -> bool {
         match *self {
-            FieldType::Message(_) | FieldType::Map(_, _) | FieldType::String_ | FieldType::Bytes => {
-                false
-            }
+            FieldType::Message(_)
+            | FieldType::Map(_, _)
+            | FieldType::String_
+            | FieldType::Bytes => false,
             _ => true,
         }
     }
@@ -71,9 +72,7 @@ impl FieldType {
     fn has_cow(&self) -> bool {
         match *self {
             FieldType::Bytes | FieldType::String_ => true,
-            FieldType::Map(ref k, ref v) => {
-                k.has_cow() || v.has_cow()
-            }
+            FieldType::Map(ref k, ref v) => k.has_cow() || v.has_cow(),
             _ => false,
         }
     }
@@ -104,7 +103,10 @@ impl FieldType {
             | FieldType::Bool
             | FieldType::Enum(_) => 0,
             FieldType::Fixed64 | FieldType::Sfixed64 | FieldType::Double => 1,
-            FieldType::String_ | FieldType::Bytes | FieldType::Message(_) | FieldType::Map(_, _) => 2,
+            FieldType::String_
+            | FieldType::Bytes
+            | FieldType::Message(_)
+            | FieldType::Map(_, _) => 2,
             FieldType::Fixed32 | FieldType::Sfixed32 | FieldType::Float => 5,
             FieldType::MessageOrEnum(_) => unreachable!("Message / Enum not resolved"),
         }
@@ -275,13 +277,11 @@ impl FieldType {
                 }
                 None => return Err(Error::MessageNotFound(msg.to_string())),
             },
-            FieldType::Map(ref key, ref value) => {
-                format!(
-                    "HashMap<{}, {}>",
-                    key.rust_type(desc)?,
-                    value.rust_type(desc)?
-                )
-            }
+            FieldType::Map(ref key, ref value) => format!(
+                "HashMap<{}, {}>",
+                key.rust_type(desc)?,
+                value.rust_type(desc)?
+            ),
             FieldType::MessageOrEnum(_) => unreachable!("Message / Enum not resolved"),
         })
     }
@@ -359,16 +359,14 @@ impl FieldType {
             FieldType::Message(_) if boxed => format!("write_message(&**{})", s),
             FieldType::Message(_) => format!("write_message({})", s),
 
-            FieldType::Map(ref k, ref v) => {
-                format!(
-                    "write_map({}, {}, |w| w.{}, {}, |w| w.{})",
-                    self.get_size(""),
-                    tag(1, k, false),
-                    k.get_write("k", false),
-                    tag(2, v, false),
-                    v.get_write("v", false)
-                )
-            }
+            FieldType::Map(ref k, ref v) => format!(
+                "write_map({}, {}, |w| w.{}, {}, |w| w.{})",
+                self.get_size(""),
+                tag(1, k, false),
+                k.get_write("k", false),
+                tag(2, v, false),
+                v.get_write("v", false)
+            ),
             FieldType::MessageOrEnum(_) => unreachable!("Message / Enum not resolved"),
         }
     }
@@ -983,10 +981,11 @@ impl Message {
             .chain(self.oneofs.iter_mut().flat_map(|o| o.fields.iter_mut()))
             .map(|f| &mut f.typ)
             .flat_map(|typ| match *typ {
-                FieldType::Map(ref mut key, ref mut value) => vec![&mut **key, &mut **value].into_iter(),
+                FieldType::Map(ref mut key, ref mut value) => {
+                    vec![&mut **key, &mut **value].into_iter()
+                }
                 _ => vec![typ].into_iter(),
-            })
-        {
+            }) {
             if let FieldType::MessageOrEnum(m) = typ.clone() {
                 *typ = if typ.find_message(&desc.messages).is_none() {
                     FieldType::Enum(m)

--- a/quick-protobuf/tests/rust_protobuf/generate.sh
+++ b/quick-protobuf/tests/rust_protobuf/generate.sh
@@ -17,6 +17,8 @@ must_fail["v2/test_root_pb.proto"]="root search is not implemented yet"
 must_fail["v3/test_enum_alias_pb.proto"]="enum alias not implemented"
 must_fail["v2/test_enum_alias_pb.proto"]="enum alias not implemented"
 must_fail["v2/test_expose_oneof_pb.proto"]="missing file"
+must_fail["v2/test_enum_invalid_default.proto"]="enum variant does not exist"
+must_fail["v3/test_enum_invalid_default.proto"]="enum variant does not exist"
 
 # Combined stdout and stderr for codegen of unexpectedly failed file.
 declare -A outs

--- a/quick-protobuf/tests/rust_protobuf/v2/test_enum_invalid_default.proto
+++ b/quick-protobuf/tests/rust_protobuf/v2/test_enum_invalid_default.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+
+enum Enum1 {
+  a = 0;
+  b = 1;
+  c = 2;
+}
+
+message Msg1 {
+  optional Enum1 x = 9 [default = a]; // a field exists
+  optional Enum1 y = 9 [default = does_not_exist]; // a field doesn't exist
+}

--- a/quick-protobuf/tests/rust_protobuf/v3/test_enum_invalid_default.proto
+++ b/quick-protobuf/tests/rust_protobuf/v3/test_enum_invalid_default.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+
+enum Enum1 {
+  a = 0;
+  b = 1;
+  c = 2;
+}
+
+message Msg1 {
+  optional Enum1 x = 9 [default = a]; // a field exists
+  optional Enum1 y = 9 [default = does_not_exist]; // a field doesn't exist
+}


### PR DESCRIPTION
MessageOrEnum being the state at the beginning of the parsing.
Also possibly fix some issue with enum in maps.

EDIT: also sanity checks that default enum values actually exist.