### PR TITLE
Correctly handle messages / enums that begin with .

### DIFF
--- a/pb-rs/src/types.rs
+++ b/pb-rs/src/types.rs
@@ -1709,7 +1709,9 @@ impl FileDescriptor {
                     _ => vec![typ].into_iter(),
                 }) {
                 if let FieldType::MessageOrEnum(name) = typ.clone() {
-                    let test_names: Vec<String> = if m.package.is_empty() {
+                    let test_names: Vec<String> = if name.starts_with(".") {
+                        vec![name.clone().split_off(1)]
+                    } else if m.package.is_empty() {
                         vec![name.clone(), format!("{}.{}", m.name, name)]
                     } else {
                         vec![

--- a/quick-protobuf/tests/rust_protobuf/generate.sh
+++ b/quick-protobuf/tests/rust_protobuf/generate.sh
@@ -13,7 +13,6 @@ have_failures=""
 declare -A must_fail
 
 must_fail["v2/test_group_pb.proto"]="expected failure (empty read)"
-must_fail["v2/test_root_pb.proto"]="root search is not implemented yet"
 must_fail["v3/test_enum_alias_pb.proto"]="enum alias not implemented"
 must_fail["v2/test_enum_alias_pb.proto"]="enum alias not implemented"
 must_fail["v2/test_expose_oneof_pb.proto"]="missing file"


### PR DESCRIPTION
As an example:

```protobuf
message CHTMLHeader {
	optional string key = 1;
	optional string value = 2;
}

message CHTMLPageSecurityInfo {
	optional bool bIsSecure = 1 [default = false];
	optional bool bHasCertError = 2 [default = false];
	optional string issuerName = 3;
	optional string certName = 4;
	optional int32 certExpiry = 5 [default = 0];
	optional int32 nCertBits = 6 [default = 0];
	optional bool bIsEVCert = 7 [default = false];
}

message CMsgFinishedRequest {
	optional uint32 browser_handle = 1;
	optional string url = 2;
	optional string pageTitle = 3;
	optional .CHTMLPageSecurityInfo security_info = 4;
	repeated .CHTMLHeader headers = 5;
}
```

`optional .CHTMLPageSecurityInfo` refers to global scope `message CHTMLPageSecurityInfo`
same with `CHTMLHeader`

Not sure if this is the most idiomatic way to do this in rust (I'm still relatively new)