### PR TITLE
make get enum pub

### DIFF
--- a/pb-rs/src/types.rs
+++ b/pb-rs/src/types.rs
@@ -88,7 +88,7 @@ pub struct EnumIndex {
 }
 
 impl EnumIndex {
-    fn get_enum<'a>(&self, desc: &'a FileDescriptor) -> &'a Enumerator {
+    pub fn get_enum<'a>(&self, desc: &'a FileDescriptor) -> &'a Enumerator {
         let enums = if self.msg_index.indexes.is_empty() {
             &desc.enums
         } else {


### PR DESCRIPTION
`get_enum ` should be public since `get_message` is public