### PR TITLE
Fix owned deref

### DIFF
--- a/pb-rs/src/types.rs
+++ b/pb-rs/src/types.rs
@@ -1104,15 +1104,15 @@ impl Message {
                 }}
             }}
 
-            #[cfg(feature = "test_helpers")]
-            impl<'a> From<{name}<'a>> for {name}Owned {{
-                fn from(proto: {name}) -> Self {{
-                    use quick_protobuf::{{MessageWrite, Writer}};
-
-                    let mut buf = Vec::new();
-                    let mut writer = Writer::new(&mut buf);
-                    proto.write_message(&mut writer).expect("bad proto serialization");
-                    Self {{ inner: {name}OwnedInner::new(buf).unwrap() }}
+            impl From<{name}<'static>> for {name}Owned {{
+                fn from(proto: {name}<'static>) -> Self {{
+                    Self {{
+                        inner: Box::pin({name}OwnedInner {{
+                            buf: Vec::new(),
+                            proto,
+                            _pin: std::marker::PhantomPinned,
+                        }})
+                    }}
                 }}
             }}
             "#,

--- a/quick-protobuf/examples/pb_rs_example_v3_owned.rs
+++ b/quick-protobuf/examples/pb_rs_example_v3_owned.rs
@@ -75,13 +75,15 @@ fn main() {
     println!("Message written successfully! bytes={:?}", &out);
 
     let read_message_owned = FooMessageOwned::try_from(out.clone()).unwrap();
+    let read_message_owned = read_message_owned.proto();
 
     println!("{:?}", read_message_owned);
-    assert_eq!(&message, &*read_message_owned);
+    assert_eq!(&message, read_message_owned);
     println!("Message read back and everything matches!");
 
     // Test mutability works too
     let mut read_message_owned_mut = FooMessageOwned::try_from(out).unwrap();
+    let mut read_message_owned_mut = read_message_owned_mut.proto_mut();
     read_message_owned_mut.f_int32 += 1;
     assert_eq!(message.f_int32 + 1, read_message_owned_mut.f_int32);
     read_message_owned_mut.f_string = "I see you, too!".into();


### PR DESCRIPTION
BREAKING CHANGE: remove *Owned Deref

The Owned PR was broken. The lifetimes of the Cow fields are wrong.
The Cow str fields of an owned proto can end up referring to garbage if
`field.to_owned()` is called and then the original field is modified or
the Owned proto is dropped.

For example, this should not compile:

```rust
let proto = FooOwned::try_from(&buf)?;
let owned_copy = proto.str_field.to_owned();
drop(proto);
println!("this code should not be valid {}", owned_copy);
```

`owned_copy` refers to nothing now.

The fix _seems_ to be to tie the transmuted lifetime of the proto to the lifetime of `&self`.

Here's a reduced example of the issue: https://github.com/nerdrew/rust-self-referential-struct/blob/master/src/main.rs#L77

When you remove the `&'b self` lifetime, the code compiles and the `cow` variable is garbage on the last line.

Without the `&'b self` lifetime:

```
% cargo run
   Compiling rust-self-referential-struct v0.1.0 (/home/lazarus/dev/tmp/rust-self-referential-struct)
    Finished dev [unoptimized + debuginfo] target(s) in 0.30s
     Running `target/debug/rust-self-referential-struct`
[src/main.rs:72] owned.buf() = "I see you"
[src/main.rs:73] &cow = "I see you"
[src/main.rs:77] &cow = "\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}u"
```

With it:

```
% cargo run
   Compiling rust-self-referential-struct v0.1.0 (/home/lazarus/dev/tmp/rust-self-referential-struct)
error[E0505]: cannot move out of `owned` because it is borrowed
  --> src/main.rs:75:10
   |
68 |     let cow = owned.cow().to_owned();
   |               ----- borrow of `owned` occurs here
...
75 |     drop(owned);
   |          ^^^^^ move out of `owned` occurs here
76 | 
77 |     dbg!(&cow);
   |          ---- borrow later used here

error: aborting due to previous error
```

Unfortunately, I don't think this is fixable while keeping the `Deref and `DerefMut` (at least I don't know how to, though I introduced this mess...).

This fix includes 3 commits:
- fix for the unsoundness issue (Sorry about that, totally my bad!)
- replace `MaybeUninit` with `Option` (much easier to think about `Option` for me)
- Improve the "test helper" `From<MyProto>` impl.

I can break this into multiple PRs if you want, since the unsoundness is a critical fix and the other two are nice-to-haves (though I think `MaybeUninit` was giving me errors or warnings with a recent nightly).