### PR TITLE
Added option to set `#[repr(...)]` on generated types.

### DIFF
--- a/pb-rs/src/lib.rs
+++ b/pb-rs/src/lib.rs
@@ -156,13 +156,13 @@ impl ConfigBuilder {
         self.custom_struct_derive = val;
         self
     }
-    
+
     /// Add custom values to `#[repr(...)]` at the beginning of every structure
     pub fn custom_repr(mut self, val: Option<String>) -> Self {
         self.custom_repr = val;
         self
     }
-    
+
     /// Use Cow<_,_> for Strings and Bytes
     pub fn dont_use_cow(mut self, val: bool) -> Self {
         self.dont_use_cow = val;

--- a/pb-rs/src/lib.rs
+++ b/pb-rs/src/lib.rs
@@ -67,6 +67,7 @@ pub struct ConfigBuilder {
     headers: bool,
     dont_use_cow: bool,
     custom_struct_derive: Vec<String>,
+    custom_repr: Option<String>,
     owned: bool,
 }
 
@@ -150,12 +151,18 @@ impl ConfigBuilder {
         self
     }
 
-    /// Add custom values to #[derive(...)] at the beginning of every structure
+    /// Add custom values to `#[derive(...)]` at the beginning of every structure
     pub fn custom_struct_derive(mut self, val: Vec<String>) -> Self {
         self.custom_struct_derive = val;
         self
     }
-
+    
+    /// Add custom values to `#[repr(...)]` at the beginning of every structure
+    pub fn custom_repr(mut self, val: Option<String>) -> Self {
+        self.custom_repr = val;
+        self
+    }
+    
     /// Use Cow<_,_> for Strings and Bytes
     pub fn dont_use_cow(mut self, val: bool) -> Self {
         self.dont_use_cow = val;
@@ -193,6 +200,7 @@ impl ConfigBuilder {
                     headers: self.headers,
                     dont_use_cow: self.dont_use_cow, //Change this to true to not use cow with ./generate.sh for v2 and v3 tests
                     custom_struct_derive: self.custom_struct_derive.clone(),
+                    custom_repr: self.custom_repr.clone(),
                     custom_rpc_generator: Box::new(|_, _| Ok(())),
                     custom_includes: Vec::new(),
                     owned: self.owned,

--- a/pb-rs/src/main.rs
+++ b/pb-rs/src/main.rs
@@ -74,7 +74,15 @@ fn run() -> Result<(), ::failure::Error> {
                 .long("custom_struct_derive")
                 .short("C")
                 .required(false)
+                .takes_value(true)
                 .help("The comma separated values to add to #[derive(...)] for every struct"),
+        ).arg(
+            Arg::with_name("CUSTOM_REPR")
+                .long("custom_repr")
+                .short("R")
+                .required(false)
+                .takes_value(true)
+                .help("The value to use for the optional #[repr(...)] for every struct"),
         ).arg(
             Arg::with_name("DONT_USE_COW")
                 .required(false)
@@ -92,6 +100,7 @@ fn run() -> Result<(), ::failure::Error> {
     let include_paths = path_vec(values_t!(matches, "INCLUDE_PATH", String));
     let out_file = matches.value_of("OUTPUT").map(|o| PathBuf::from(o));
     let out_dir = matches.value_of("OUTPUT_DIR").map(|o| PathBuf::from(o));
+    let custom_repr = matches.value_of("CUSTOM_REPR").map(|o| o.into());
     let custom_struct_derive: Vec<String> = matches
         .value_of("CUSTOM_STRUCT_DERIVE")
         .unwrap_or("")
@@ -111,6 +120,7 @@ fn run() -> Result<(), ::failure::Error> {
     .headers(!matches.is_present("NO_HEADERS"))
     .dont_use_cow(matches.is_present("DONT_USE_COW"))
     .custom_struct_derive(custom_struct_derive)
+    .custom_repr(custom_repr)
     .owned(matches.is_present("OWNED"));
 
     FileDescriptor::run(&compiler.build()).map_err(|e| e.into())

--- a/pb-rs/src/types.rs
+++ b/pb-rs/src/types.rs
@@ -897,11 +897,11 @@ impl Message {
             "#[derive({}Debug, Default, PartialEq, Clone)]",
             custom_struct_derive
         )?;
-        
+
         if let Some(repr) = &config.custom_repr {
             writeln!(w, "#[repr({})]", repr)?;
         }
-        
+
         if self.is_unit() {
             writeln!(w, "pub struct {} {{ }}", self.name)?;
             return Ok(());

--- a/pb-rs/src/types.rs
+++ b/pb-rs/src/types.rs
@@ -897,6 +897,11 @@ impl Message {
             "#[derive({}Debug, Default, PartialEq, Clone)]",
             custom_struct_derive
         )?;
+        
+        if let Some(repr) = &config.custom_repr {
+            writeln!(w, "#[repr({})]", repr)?;
+        }
+        
         if self.is_unit() {
             writeln!(w, "pub struct {} {{ }}", self.name)?;
             return Ok(());
@@ -1647,6 +1652,7 @@ pub struct Config {
     pub headers: bool,
     pub dont_use_cow: bool,
     pub custom_struct_derive: Vec<String>,
+    pub custom_repr: Option<String>,
     pub custom_rpc_generator: RpcGeneratorFunction,
     pub custom_includes: Vec<String>,
     pub owned: bool,

--- a/perftest/build.rs
+++ b/perftest/build.rs
@@ -58,6 +58,7 @@ fn main() {
         headers: false,
         dont_use_cow: false,
         custom_struct_derive: vec![],
+        custom_repr: None,
         custom_rpc_generator: Box::new(|rpc, writer| generate_rpc_test(rpc, writer)),
         custom_includes: Vec::new(),
         owned: false,


### PR DESCRIPTION
Hi, 

I added an option to specify a custom `#[repr(...)]`. We need this in our project since we also want to use the generated types as part of an FFI interface. 

PR includes a small bugfix that `custom_struct_derive` in the CLI wasn't annotated with `.takes_value(true)`.

Let me know if you want something changed!