### PR TITLE
Attribute #![allow(clippy)] is deprecated, use #![allow(clippy::all)]…

### DIFF
--- a/pb-rs/src/types.rs
+++ b/pb-rs/src/types.rs
@@ -2131,7 +2131,7 @@ impl FileDescriptor {
         writeln!(w, "#![allow(non_camel_case_types)]")?;
         writeln!(w, "#![allow(unused_imports)]")?;
         writeln!(w, "#![allow(unknown_lints)]")?;
-        writeln!(w, "#![allow(clippy)]")?;
+        writeln!(w, "#![allow(clippy::all)]")?;
 
         writeln!(w, "#![cfg_attr(rustfmt, rustfmt_skip)]")?;
         writeln!(w, "")?;


### PR DESCRIPTION
… instead

Signed-off-by: Daniel Egger <daniel@eggers-club.de>