### PR TITLE
Allow hexadecimal tag numbers in pb-rs

### DIFF
--- a/pb-rs/src/parser.rs
+++ b/pb-rs/src/parser.rs
@@ -242,7 +242,7 @@ named!(
             >> many0!(br)
             >> tag!("=")
             >> many0!(br)
-            >> number: integer
+            >> number: alt!(hex_integer | integer)
             >> many0!(br)
             >> key_vals: many0!(key_val)
             >> tag!(";")


### PR DESCRIPTION
Some of the 3rd party protobuf definitions I'm working with have the field tags specified in hex, the fix seems quick enough.

Thanks for the library!