### PR TITLE
Don't force inlining on `no_std`

### DIFF
--- a/quick-protobuf/src/reader.rs
+++ b/quick-protobuf/src/reader.rs
@@ -91,13 +91,13 @@ impl BytesReader {
     }
 
     /// Reads next tag, `None` if all bytes have been read
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn next_tag(&mut self, bytes: &[u8]) -> Result<u32> {
         self.read_varint32(bytes)
     }
 
     /// Reads the next byte
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn read_u8(&mut self, bytes: &[u8]) -> Result<u8> {
         let b = bytes.get(self.start).ok_or(Error::UnexpectedEndOfBuffer)?;
         self.start += 1;
@@ -105,7 +105,7 @@ impl BytesReader {
     }
 
     /// Reads the next varint encoded u64
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn read_varint32(&mut self, bytes: &[u8]) -> Result<u32> {
         let mut b = self.read_u8(bytes)?;
         if b & 0x80 == 0 {
@@ -149,7 +149,7 @@ impl BytesReader {
     }
 
     /// Reads the next varint encoded u64
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn read_varint64(&mut self, bytes: &[u8]) -> Result<u64> {
         // part0
         let mut b = self.read_u8(bytes)?;
@@ -219,31 +219,31 @@ impl BytesReader {
     }
 
     /// Reads int32 (varint)
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_int32(&mut self, bytes: &[u8]) -> Result<i32> {
         self.read_varint32(bytes).map(|i| i as i32)
     }
 
     /// Reads int64 (varint)
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_int64(&mut self, bytes: &[u8]) -> Result<i64> {
         self.read_varint64(bytes).map(|i| i as i64)
     }
 
     /// Reads uint32 (varint)
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_uint32(&mut self, bytes: &[u8]) -> Result<u32> {
         self.read_varint32(bytes)
     }
 
     /// Reads uint64 (varint)
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_uint64(&mut self, bytes: &[u8]) -> Result<u64> {
         self.read_varint64(bytes)
     }
 
     /// Reads sint32 (varint)
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_sint32(&mut self, bytes: &[u8]) -> Result<i32> {
         // zigzag
         let n = self.read_varint32(bytes)?;
@@ -251,7 +251,7 @@ impl BytesReader {
     }
 
     /// Reads sint64 (varint)
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_sint64(&mut self, bytes: &[u8]) -> Result<i64> {
         // zigzag
         let n = self.read_varint64(bytes)?;
@@ -259,7 +259,7 @@ impl BytesReader {
     }
 
     /// Reads fixed64 (little endian u64)
-    #[inline]
+    #[cfg_attr(std, inline)]
     fn read_fixed<M, F: Fn(&[u8]) -> M>(&mut self, bytes: &[u8], len: usize, read: F) -> Result<M> {
         let v = read(
             &bytes
@@ -271,55 +271,55 @@ impl BytesReader {
     }
 
     /// Reads fixed64 (little endian u64)
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_fixed64(&mut self, bytes: &[u8]) -> Result<u64> {
         self.read_fixed(bytes, 8, LE::read_u64)
     }
 
     /// Reads fixed32 (little endian u32)
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_fixed32(&mut self, bytes: &[u8]) -> Result<u32> {
         self.read_fixed(bytes, 4, LE::read_u32)
     }
 
     /// Reads sfixed64 (little endian i64)
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_sfixed64(&mut self, bytes: &[u8]) -> Result<i64> {
         self.read_fixed(bytes, 8, LE::read_i64)
     }
 
     /// Reads sfixed32 (little endian i32)
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_sfixed32(&mut self, bytes: &[u8]) -> Result<i32> {
         self.read_fixed(bytes, 4, LE::read_i32)
     }
 
     /// Reads float (little endian f32)
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_float(&mut self, bytes: &[u8]) -> Result<f32> {
         self.read_fixed(bytes, 4, LE::read_f32)
     }
 
     /// Reads double (little endian f64)
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_double(&mut self, bytes: &[u8]) -> Result<f64> {
         self.read_fixed(bytes, 8, LE::read_f64)
     }
 
     /// Reads bool (varint, check if == 0)
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_bool(&mut self, bytes: &[u8]) -> Result<bool> {
         self.read_varint32(bytes).map(|i| i != 0)
     }
 
     /// Reads enum, encoded as i32
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_enum<E: From<i32>>(&mut self, bytes: &[u8]) -> Result<E> {
         self.read_int32(bytes).map(|e| e.into())
     }
 
     /// First reads a varint and use it as size to read a generic object
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     fn read_len_varint<'a, M, F>(&mut self, bytes: &'a [u8], read: F) -> Result<M>
     where
         F: FnMut(&mut BytesReader, &'a [u8]) -> Result<M>,
@@ -329,7 +329,7 @@ impl BytesReader {
     }
 
     /// Reads a certain number of bytes specified by len
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     fn read_len<'a, M, F>(&mut self, bytes: &'a [u8], mut read: F, len: usize) -> Result<M>
     where
         F: FnMut(&mut BytesReader, &'a [u8]) -> Result<M>,
@@ -343,7 +343,7 @@ impl BytesReader {
     }
 
     /// Reads bytes (Vec<u8>)
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_bytes<'a>(&mut self, bytes: &'a [u8]) -> Result<&'a [u8]> {
         self.read_len_varint(bytes, |r, b| {
             b.get(r.start..r.end)
@@ -352,7 +352,7 @@ impl BytesReader {
     }
 
     /// Reads string (String)
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_string<'a>(&mut self, bytes: &'a [u8]) -> Result<&'a str> {
         self.read_len_varint(bytes, |r, b| {
             b.get(r.start..r.end)
@@ -365,7 +365,7 @@ impl BytesReader {
     ///
     /// Note: packed field are stored as a variable length chunk of data, while regular repeated
     /// fields behaves like an iterator, yielding their tag everytime
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_packed<'a, M, F>(&mut self, bytes: &'a [u8], mut read: F) -> Result<Vec<M>>
     where
         F: FnMut(&mut BytesReader, &'a [u8]) -> Result<M>,
@@ -383,7 +383,7 @@ impl BytesReader {
     ///
     /// Note: packed field are stored as a variable length chunk of data, while regular repeated
     /// fields behaves like an iterator, yielding their tag everytime
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_packed_fixed<'a, M>(&mut self, bytes: &'a [u8]) -> Result<&'a [M]> {
         let len = self.read_varint32(bytes)? as usize;
         if self.len() < len {
@@ -403,7 +403,7 @@ impl BytesReader {
     /// Reads a nested message
     ///
     /// First reads a varint and interprets it as the length of the message
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_message<'a, M>(&mut self, bytes: &'a [u8]) -> Result<M>
     where
         M: MessageRead<'a>,
@@ -415,7 +415,7 @@ impl BytesReader {
     ///
     /// Reads just the message and does not try to read it's size first.
     ///  * 'len' - The length of the message to be read.
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_message_by_len<'a, M>(&mut self, bytes: &'a [u8], len: usize) -> Result<M>
     where
         M: MessageRead<'a>,
@@ -424,7 +424,7 @@ impl BytesReader {
     }
 
     /// Reads a map item: (key, value)
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_map<'a, K, V, F, G>(
         &mut self,
         bytes: &'a [u8],
@@ -453,7 +453,7 @@ impl BytesReader {
     }
 
     /// Reads unknown data, based on its tag value (which itself gives us the wire_type value)
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read_unknown(&mut self, bytes: &[u8], tag_value: u32) -> Result<()> {
         match (tag_value & 0x7) as u8 {
             WIRE_TYPE_VARINT => {
@@ -476,13 +476,13 @@ impl BytesReader {
     }
 
     /// Gets the remaining length of bytes not read yet
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn len(&self) -> usize {
         self.end - self.start
     }
 
     /// Checks if `self.len == 0`
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn is_eof(&self) -> bool {
         self.start == self.end
     }
@@ -580,7 +580,7 @@ impl Reader {
     }
 
     /// Run a `BytesReader` dependent function
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn read<'a, M, F>(&'a mut self, mut read: F) -> Result<M>
     where
         F: FnMut(&mut BytesReader, &'a [u8]) -> Result<M>,

--- a/quick-protobuf/src/writer.rs
+++ b/quick-protobuf/src/writer.rs
@@ -76,105 +76,105 @@ impl<W: WriterBackend> Writer<W> {
     }
 
     /// Writes a tag, which represents both the field number and the wire type
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn write_tag(&mut self, tag: u32) -> Result<()> {
         self.write_varint(tag as u64)
     }
 
     /// Writes a `int32` which is internally coded as a `varint`
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn write_int32(&mut self, v: i32) -> Result<()> {
         self.write_varint(v as u64)
     }
 
     /// Writes a `int64` which is internally coded as a `varint`
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn write_int64(&mut self, v: i64) -> Result<()> {
         self.write_varint(v as u64)
     }
 
     /// Writes a `uint32` which is internally coded as a `varint`
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn write_uint32(&mut self, v: u32) -> Result<()> {
         self.write_varint(v as u64)
     }
 
     /// Writes a `uint64` which is internally coded as a `varint`
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn write_uint64(&mut self, v: u64) -> Result<()> {
         self.write_varint(v)
     }
 
     /// Writes a `sint32` which is internally coded as a `varint`
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn write_sint32(&mut self, v: i32) -> Result<()> {
         self.write_varint(((v << 1) ^ (v >> 31)) as u64)
     }
 
     /// Writes a `sint64` which is internally coded as a `varint`
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn write_sint64(&mut self, v: i64) -> Result<()> {
         self.write_varint(((v << 1) ^ (v >> 63)) as u64)
     }
 
     /// Writes a `fixed64` which is little endian coded `u64`
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn write_fixed64(&mut self, v: u64) -> Result<()> {
         self.inner.pb_write_u64(v)
     }
 
     /// Writes a `fixed32` which is little endian coded `u32`
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn write_fixed32(&mut self, v: u32) -> Result<()> {
         self.inner.pb_write_u32(v)
     }
 
     /// Writes a `sfixed64` which is little endian coded `i64`
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn write_sfixed64(&mut self, v: i64) -> Result<()> {
         self.inner.pb_write_i64(v)
     }
 
     /// Writes a `sfixed32` which is little endian coded `i32`
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn write_sfixed32(&mut self, v: i32) -> Result<()> {
         self.inner.pb_write_i32(v)
     }
 
     /// Writes a `float`
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn write_float(&mut self, v: f32) -> Result<()> {
         self.inner.pb_write_f32(v)
     }
 
     /// Writes a `double`
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn write_double(&mut self, v: f64) -> Result<()> {
         self.inner.pb_write_f64(v)
     }
 
     /// Writes a `bool` 1 = true, 0 = false
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn write_bool(&mut self, v: bool) -> Result<()> {
         self.inner
             .pb_write_u8(if v { 1 } else { 0 })
     }
 
     /// Writes an `enum` converting it to a `i32` first
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn write_enum(&mut self, v: i32) -> Result<()> {
         self.write_int32(v)
     }
 
     /// Writes `bytes`: length first then the chunk of data
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn write_bytes(&mut self, bytes: &[u8]) -> Result<()> {
         self.write_varint(bytes.len() as u64)?;
         self.inner.pb_write_all(bytes)
     }
 
     /// Writes `string`: length first then the chunk of data
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     pub fn write_string(&mut self, s: &str) -> Result<()> {
         self.write_bytes(s.as_bytes())
     }
@@ -201,7 +201,7 @@ impl<W: WriterBackend> Writer<W> {
     /// `item_size` is internally used to compute the total length
     /// As the length is fixed (and the same as rust internal representation, we can directly dump
     /// all data at once
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn write_packed_fixed<M>(&mut self, v: &[M]) -> Result<()> {
         let len = v.len() * ::core::mem::size_of::<M>();
         let bytes = unsafe { ::core::slice::from_raw_parts(v.as_ptr() as *const u8, len) };
@@ -209,7 +209,7 @@ impl<W: WriterBackend> Writer<W> {
     }
 
     /// Writes a message which implements `MessageWrite`
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn write_message<M: MessageWrite>(&mut self, m: &M) -> Result<()> {
         let len = m.get_size();
         self.write_varint(len as u64)?;
@@ -217,7 +217,7 @@ impl<W: WriterBackend> Writer<W> {
     }
 
     /// Writes another item prefixed with tag
-    #[inline]
+    #[cfg_attr(std, inline)]
     pub fn write_with_tag<F>(&mut self, tag: u32, mut write: F) -> Result<()>
     where
         F: FnMut(&mut Self) -> Result<()>,
@@ -374,7 +374,7 @@ impl<'a> BytesWriter<'a> {
 }
 
 impl<'a> WriterBackend for BytesWriter<'a> {
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     fn pb_write_u8(&mut self, x: u8) -> Result<()> {
         if self.buf.len() - self.cursor < 1 {
             Err(Error::UnexpectedEndOfBuffer)
@@ -385,7 +385,7 @@ impl<'a> WriterBackend for BytesWriter<'a> {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     fn pb_write_u32(&mut self, x: u32) -> Result<()> {
         if self.buf.len() - self.cursor < 4 {
             Err(Error::UnexpectedEndOfBuffer)
@@ -396,7 +396,7 @@ impl<'a> WriterBackend for BytesWriter<'a> {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     fn pb_write_i32(&mut self, x: i32) -> Result<()> {
         if self.buf.len() - self.cursor < 4 {
             Err(Error::UnexpectedEndOfBuffer)
@@ -407,7 +407,7 @@ impl<'a> WriterBackend for BytesWriter<'a> {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     fn pb_write_f32(&mut self, x: f32) -> Result<()> {
         if self.buf.len() - self.cursor < 4 {
             Err(Error::UnexpectedEndOfBuffer)
@@ -418,7 +418,7 @@ impl<'a> WriterBackend for BytesWriter<'a> {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     fn pb_write_u64(&mut self, x: u64) -> Result<()> {
         if self.buf.len() - self.cursor < 8 {
             Err(Error::UnexpectedEndOfBuffer)
@@ -429,7 +429,7 @@ impl<'a> WriterBackend for BytesWriter<'a> {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     fn pb_write_i64(&mut self, x: i64) -> Result<()> {
         if self.buf.len() - self.cursor < 8 {
             Err(Error::UnexpectedEndOfBuffer)
@@ -440,7 +440,7 @@ impl<'a> WriterBackend for BytesWriter<'a> {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     fn pb_write_f64(&mut self, x: f64) -> Result<()> {
         if self.buf.len() - self.cursor < 8 {
             Err(Error::UnexpectedEndOfBuffer)
@@ -451,7 +451,7 @@ impl<'a> WriterBackend for BytesWriter<'a> {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(std, inline(always))]
     fn pb_write_all(&mut self, buf: &[u8]) -> Result<()> {
         if self.buf.len() - self.cursor < buf.len() {
             Err(Error::UnexpectedEndOfBuffer)


### PR DESCRIPTION
Hi @tafia !

I propose to don't force `inline` directive when `no_std` enabled. Forced code inline leads to huge stack sizes and when we have little memory in the embedded CPU it is matter.