### PR TITLE
Fix update mod.rs for 'package a.b.c' case

### DIFF
--- a/pb-rs/src/types.rs
+++ b/pb-rs/src/types.rs
@@ -1770,10 +1770,11 @@ impl FileDescriptor {
             out_file.pop();
             for p in prefix.split('.') {
                 out_file.push(p);
-            }
-            if !out_file.exists() {
-                create_dir_all(&out_file)?;
-                update_mod_file(&out_file)?;
+
+                if !out_file.exists() {
+                    create_dir_all(&out_file)?;
+                    update_mod_file(&out_file)?;
+                }
             }
             out_file.push(file);
         }


### PR DESCRIPTION
Hi @tafia !

I have encounter problem when use triple nested package such as

```protobuf
syntax = "proto2";

package a.b.c;

message ...
```

Root `mod.rs` file does not contain `pub mod a;` string.
If I use `package a.b;` all OK.

This PR works OK for both cases.
If you wish I may add a test for 'a.b.c' case.
