### PR TITLE
pb_rs: Make main.rs dependencies optional

### DIFF
--- a/pb-rs/Cargo.toml
+++ b/pb-rs/Cargo.toml
@@ -11,13 +11,14 @@ edition = "2018"
 
 [dependencies]
 nom = "3.2.1"
-clap = "2.33.1"
 log = "0.4.4"
-env_logger = "0.7.1"
+clap = { version = "2.33.1", optional = true }
+env_logger = { version = "0.7.1", optional = true }
 
 [dev-dependencies]
 walkdir = "2.3.1"
 
 [features]
-default = []
+default = ["std"]
+std = ["clap", "env_logger"]
 generateImplFromForEnums = []


### PR DESCRIPTION
Hi @tafia !

I use `quick-protobuf` in the `no_std` env. When I link `pb_rs` as `build-dependency` to my crate I get following error:
```
   Compiling memchr v2.3.3
   Compiling env_logger v0.7.1
error[E0463]: can't find crate for `std`
  |
  = note: the `thumbv7m-none-eabi` target may not be installed

error: aborting due to previous error

For more information about this error, try `rustc --explain E0463`.
error: could not compile `memchr`.
```

It seems `env_logger` & `clap` crates somehow "leak" their deps into the dependency tree.

I made those deps optional because when using `pb_rs` as a library they don't need.
