### PR TITLE
Remove proc from keywords

### DIFF
--- a/pb-rs/src/keywords.rs
+++ b/pb-rs/src/keywords.rs
@@ -43,7 +43,6 @@ static RUST_KEYWORDS: [&str; 76] = [
     "Option",
     "override",
     "priv",
-    "proc",
     "pub",
     "pure",
     "ref",


### PR DESCRIPTION
Remove proc from keywords. https://doc.rust-lang.org/reference/keywords.html