### PR TITLE
Fix warning 'type alias is never used: `KVMap`'

### DIFF
--- a/pb-rs/src/types.rs
+++ b/pb-rs/src/types.rs
@@ -2277,6 +2277,7 @@ impl FileDescriptor {
         if self
             .messages
             .iter()
+            .filter(|m| !m.imported)
             .any(|m| m.all_fields().any(|f| f.typ.is_map()))
         {
             if config.hashbrown {


### PR DESCRIPTION
Hi @tafia,

That change fixes rustc's warning that appears when compiling code generated for protobuf file that imports message that contains a map type.

Example:

```protobuf
syntax = "proto2";

import "params.proto"; // contains a message with a map type

message Msg { // this message doesn't contains map type
    required params.Params params = 1;
}
```

Code generated for such file doesn't need to declare `KVMap` type.