### PR TITLE
Replaced nom 3.2 with 7. This replaces the entire parser module.

### DIFF
--- a/pb-rs/Cargo.toml
+++ b/pb-rs/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/tafia/quick-protobuf"
 edition = "2018"
 
 [dependencies]
-nom = "3.2.1"
+nom = "7"
 log = "0.4.4"
 clap = { version = "2.33.1", optional = true }
 env_logger = { version = "0.7.1", optional = true }

--- a/pb-rs/src/errors.rs
+++ b/pb-rs/src/errors.rs
@@ -6,7 +6,7 @@ pub enum Error {
     /// IO error
     Io(io::Error),
     /// Nom Error
-    Nom(::nom::simple_errors::Err),
+    Nom(nom::Err<nom::error::Error<String>>),
     /// No .proto file provided
     NoProto,
     /// Cannot read input file

--- a/pb-rs/src/lib.rs
+++ b/pb-rs/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate nom;
-
 pub mod errors;
 mod keywords;
 mod parser;

--- a/pb-rs/src/parser.rs
+++ b/pb-rs/src/parser.rs
@@ -1,330 +1,22 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::str;
 
 use crate::types::{
     Enumerator, Field, FieldType, FileDescriptor, Frequency, Message, OneOf,
     RpcFunctionDeclaration, RpcService, Syntax,
 };
-use nom::{digit, hex_digit, multispace};
 
-fn is_word(b: u8) -> bool {
-    match b {
-        b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' | b'.' => true,
-        _ => false,
-    }
-}
+use nom::{
+    branch::alt,
+    bytes::complete::{tag, take_until},
+    character::complete::{alphanumeric1, digit1, hex_digit1, line_ending, multispace1},
+    combinator::{map, map_res, not, opt, recognize, value},
+    multi::{many0, many1, separated_list0, separated_list1},
+    sequence::{delimited, pair, preceded, separated_pair, terminated, tuple},
+    IResult,
+};
 
-named!(
-    word<String>,
-    map_res!(take_while!(is_word), |b: &[u8]| String::from_utf8(
-        b.to_vec()
-    ))
-);
-named!(
-    word_ref<&str>,
-    map_res!(take_while!(is_word), str::from_utf8)
-);
-
-named!(
-    hex_integer<i32>,
-    do_parse!(
-        tag!("0x")
-            >> num: map_res!(
-                map_res!(hex_digit, str::from_utf8),
-                |s| i32::from_str_radix(s, 16)
-            )
-            >> (num)
-    )
-);
-
-named!(
-    integer<i32>,
-    map_res!(map_res!(digit, str::from_utf8), str::FromStr::from_str)
-);
-
-named!(
-    comment<()>,
-    do_parse!(tag!("//") >> take_until_and_consume!("\n") >> ())
-);
-named!(
-    block_comment<()>,
-    do_parse!(tag!("/*") >> take_until_and_consume!("*/") >> ())
-);
-
-// word break: multispace or comment
-named!(
-    br<()>,
-    alt!(map!(multispace, |_| ()) | comment | block_comment)
-);
-
-named!(
-    syntax<Syntax>,
-    do_parse!(
-        tag!("syntax")
-            >> many0!(br)
-            >> tag!("=")
-            >> many0!(br)
-            >> proto:
-                alt!(tag!("\"proto2\"") => { |_| Syntax::Proto2 } |
-                             tag!("\"proto3\"") => { |_| Syntax::Proto3 })
-            >> many0!(br)
-            >> tag!(";")
-            >> (proto)
-    )
-);
-
-named!(
-    import<PathBuf>,
-    do_parse!(
-        tag!("import")
-            >> many1!(br)
-            >> tag!("\"")
-            >> path: map!(map_res!(take_until!("\""), str::from_utf8), |s| Path::new(
-                s
-            )
-            .into())
-            >> tag!("\"")
-            >> many0!(br)
-            >> tag!(";")
-            >> (path)
-    )
-);
-
-named!(
-    package<String>,
-    do_parse!(
-        tag!("package") >> many1!(br) >> package: word >> many0!(br) >> tag!(";") >> (package)
-    )
-);
-
-named!(
-    extensions<()>,
-    do_parse!(tag!("extensions") >> take_until_and_consume!(";") >> ())
-);
-
-named!(
-    num_range<Vec<i32>>,
-    do_parse!(
-        from_: integer
-            >> many1!(br)
-            >> tag!("to")
-            >> many1!(br)
-            >> to_: integer
-            >> ((from_..(to_ + 1)).collect())
-    )
-);
-
-named!(
-    reserved_nums<Vec<i32>>,
-    do_parse!(
-        tag!("reserved")
-            >> many1!(br)
-            >> nums: separated_list!(
-                do_parse!(many0!(br) >> tag!(",") >> many0!(br) >> (())),
-                alt!(num_range | integer => { |i| vec![i] })
-            )
-            >> many0!(br)
-            >> tag!(";")
-            >> (nums.into_iter().flat_map(|v| v.into_iter()).collect())
-    )
-);
-
-named!(
-    reserved_names<Vec<String>>,
-    do_parse!(
-        tag!("reserved")
-            >> many1!(br)
-            >> names:
-                many1!(do_parse!(
-                    tag!("\"")
-                        >> name: word
-                        >> tag!("\"")
-                        >> many0!(alt!(br | tag!(",") => { |_| () }))
-                        >> (name)
-                ))
-            >> many0!(br)
-            >> tag!(";")
-            >> (names)
-    )
-);
-
-named!(
-    key_val<(&str, &str)>,
-    do_parse!(
-        tag!("[")
-            >> many0!(br)
-            >> key: word_ref
-            >> many0!(br)
-            >> tag!("=")
-            >> many0!(br)
-            >> value: map_res!(is_not!("]"), str::from_utf8)
-            >> tag!("]")
-            >> many0!(br)
-            >> ((key, value.trim()))
-    )
-);
-
-named!(
-    frequency<Frequency>,
-    alt!(tag!("optional") => { |_| Frequency::Optional } |
-            tag!("repeated") => { |_| Frequency::Repeated } |
-            tag!("required") => { |_| Frequency::Required } )
-);
-
-named!(
-    field_type<FieldType>,
-    alt!(tag!("int32") => { |_| FieldType::Int32 } |
-            tag!("int64") => { |_| FieldType::Int64 } |
-            tag!("uint32") => { |_| FieldType::Uint32 } |
-            tag!("uint64") => { |_| FieldType::Uint64 } |
-            tag!("sint32") => { |_| FieldType::Sint32 } |
-            tag!("sint64") => { |_| FieldType::Sint64 } |
-            tag!("fixed32") => { |_| FieldType::Fixed32 } |
-            tag!("sfixed32") => { |_| FieldType::Sfixed32 } |
-            tag!("fixed64") => { |_| FieldType::Fixed64 } |
-            tag!("sfixed64") => { |_| FieldType::Sfixed64 } |
-            tag!("bool") => { |_| FieldType::Bool } |
-            tag!("string") => { |_| FieldType::StringCow } |
-            tag!("bytes") => { |_| FieldType::BytesCow } |
-            tag!("float") => { |_| FieldType::Float } |
-            tag!("double") => { |_| FieldType::Double } |
-            map_field => { |(k, v)| FieldType::Map(Box::new(k), Box::new(v)) } |
-            word => { |w| FieldType::MessageOrEnum(w) })
-);
-
-named!(
-    map_field<(FieldType, FieldType)>,
-    do_parse!(
-        tag!("map")
-            >> many0!(br)
-            >> tag!("<")
-            >> many0!(br)
-            >> key: field_type
-            >> many0!(br)
-            >> tag!(",")
-            >> many0!(br)
-            >> value: field_type
-            >> tag!(">")
-            >> ((key, value))
-    )
-);
-
-named!(
-    one_of<OneOf>,
-    do_parse!(
-        tag!("oneof")
-            >> many1!(br)
-            >> name: word
-            >> many0!(br)
-            >> tag!("{")
-            >> fields: many1!(message_field)
-            >> many0!(br)
-            >> tag!("}")
-            >> many0!(br)
-            >> (OneOf {
-                name: name,
-                fields: fields,
-                package: "".to_string(),
-                module: "".to_string(),
-                imported: false,
-            })
-    )
-);
-
-named!(
-    message_field<Field>,
-    do_parse!(
-        frequency: opt!(frequency)
-            >> many0!(br)
-            >> typ: field_type
-            >> many1!(br)
-            >> name: word
-            >> many0!(br)
-            >> tag!("=")
-            >> many0!(br)
-            >> number: alt!(hex_integer | integer)
-            >> many0!(br)
-            >> key_vals: many0!(key_val)
-            >> tag!(";")
-            >> (Field {
-                name: name,
-                frequency: frequency.unwrap_or(Frequency::Optional),
-                number: number,
-                default: key_vals
-                    .iter()
-                    .find(|&&(k, _)| k == "default")
-                    .map(|&(_, v)| v.to_string()),
-                packed: key_vals
-                    .iter()
-                    .find(|&&(k, _)| k == "packed")
-                    .map(|&(_, v)| str::FromStr::from_str(v).expect("Cannot parse Packed value")),
-                boxed: false,
-                typ: typ,
-                deprecated: key_vals
-                    .iter()
-                    .find(|&&(k, _)| k == "deprecated")
-                    .map_or(false, |&(_, v)| str::FromStr::from_str(v)
-                        .expect("Cannot parse Deprecated value")),
-            })
-    )
-);
-
-named!(
-    rpc_function_declaration<RpcFunctionDeclaration>,
-    do_parse!(
-        tag!("rpc")
-            >> many1!(br)
-            >> name: word
-            >> many0!(br)
-            >> tag!("(")
-            >> many0!(br)
-            >> arg: word
-            >> many0!(br)
-            >> tag!(")")
-            >> many1!(br)
-            >> tag!("returns")
-            >> many1!(br)
-            >> tag!("(")
-            >> many0!(br)
-            >> ret: word
-            >> many0!(br)
-            >> tag!(")")
-            >> many0!(br)
-            >> alt!(
-                do_parse!(
-                    tuple!(
-                        tag!("{"),
-                        many0!(br),
-                        many0!(alt!(option_ignore | map!(tag!(";"), |_| ()))),
-                        many0!(br),
-                        tag!("}")
-                    ) >> ()
-                ) | map!(tag!(";"), |_| ())
-            )
-            >> many0!(br)
-            >> (RpcFunctionDeclaration { name, arg, ret })
-    )
-);
-
-named!(
-    rpc_service<RpcService>,
-    do_parse!(
-        tag!("service")
-            >> many1!(br)
-            >> service_name: dbg!(word)
-            >> many0!(br)
-            >> tag!("{")
-            >> many0!(br)
-            >> functions: many0!(rpc_function_declaration)
-            >> many0!(br)
-            >> tag!("}")
-            >> (RpcService {
-                service_name,
-                functions
-            })
-    )
-);
-
+#[derive(Debug, Clone)]
 enum MessageEvent {
     Message(Message),
     Enumerator(Enumerator),
@@ -335,103 +27,7 @@ enum MessageEvent {
     Ignore,
 }
 
-named!(
-    message_event<MessageEvent>,
-    alt!(reserved_nums => { |r| MessageEvent::ReservedNums(r) } |
-                                         reserved_names => { |r| MessageEvent::ReservedNames(r) } |
-                                         message_field => { |f| MessageEvent::Field(f) } |
-                                         message => { |m| MessageEvent::Message(m) } |
-                                         enumerator => { |e| MessageEvent::Enumerator(e) } |
-                                         one_of => { |o| MessageEvent::OneOf(o) } |
-                                         extensions => { |_| MessageEvent::Ignore } |
-                                         br => { |_| MessageEvent::Ignore })
-);
-
-named!(
-    message_events<(String, Vec<MessageEvent>)>,
-    do_parse!(
-        tag!("message")
-            >> many1!(br)
-            >> name: word
-            >> many0!(br)
-            >> tag!("{")
-            >> many0!(br)
-            >> events: many0!(message_event)
-            >> many0!(br)
-            >> tag!("}")
-            >> many0!(br)
-            >> many0!(tag!(";"))
-            >> ((name, events))
-    )
-);
-
-named!(
-    message<Message>,
-    map!(message_events, |(name, events): (
-        String,
-        Vec<MessageEvent>
-    )| {
-        let mut msg = Message {
-            name,
-            ..Message::default()
-        };
-        for e in events {
-            match e {
-                MessageEvent::Field(f) => msg.fields.push(f),
-                MessageEvent::ReservedNums(r) => msg.reserved_nums = Some(r),
-                MessageEvent::ReservedNames(r) => msg.reserved_names = Some(r),
-                MessageEvent::Message(m) => msg.messages.push(m),
-                MessageEvent::Enumerator(e) => msg.enums.push(e),
-                MessageEvent::OneOf(o) => msg.oneofs.push(o),
-                MessageEvent::Ignore => (),
-            }
-        }
-        msg
-    })
-);
-
-named!(
-    enum_field<(String, i32)>,
-    do_parse!(
-        name: word
-            >> many0!(br)
-            >> tag!("=")
-            >> many0!(br)
-            >> number: alt!(hex_integer | integer)
-            >> many0!(br)
-            >> tag!(";")
-            >> many0!(br)
-            >> ((name, number))
-    )
-);
-
-named!(
-    enumerator<Enumerator>,
-    do_parse!(
-        tag!("enum")
-            >> many1!(br)
-            >> name: word
-            >> many0!(br)
-            >> tag!("{")
-            >> many0!(br)
-            >> fields: many0!(enum_field)
-            >> many0!(br)
-            >> tag!("}")
-            >> many0!(br)
-            >> many0!(tag!(";"))
-            >> (Enumerator {
-                name: name,
-                fields: fields,
-                ..Enumerator::default()
-            })
-    )
-);
-
-named!(
-    option_ignore<()>,
-    do_parse!(tag!("option") >> many1!(br) >> take_until_and_consume!(";") >> ())
-);
-
+#[derive(Debug, Clone)]
 enum Event {
     Syntax(Syntax),
     Import(PathBuf),
@@ -442,38 +38,389 @@ enum Event {
     Ignore,
 }
 
-named!(
-    event<Event>,
-    alt!(syntax => { |s| Event::Syntax(s) } |
-            import => { |i| Event::Import(i) } |
-            package => { |p| Event::Package(p) } |
-            message => { |m| Event::Message(m) } |
-            enumerator => { |e| Event::Enum(e) } |
-            rpc_service => { |r| Event::RpcService(r) } |
-            option_ignore => { |_| Event::Ignore } |
-            br => { |_| Event::Ignore })
-);
+fn word_ref(input: &str) -> IResult<&str, &str> {
+    recognize(many0(alt((alphanumeric1, tag("_"), tag(".")))))(input)
+}
 
-named!(pub file_descriptor<FileDescriptor>,
-map!(many0!(event), |events: Vec<Event>| {
-    let mut desc = FileDescriptor::default();
-    for event in events {
-        match event {
-            Event::Syntax(s) => desc.syntax = s,
-            Event::Import(i) => desc.import_paths.push(i),
-            Event::Package(p) => desc.package = p,
-            Event::Message(m) => desc.messages.push(m),
-            Event::Enum(e) => desc.enums.push(e),
-            Event::RpcService(r) => desc.rpc_services.push(r),
-            Event::Ignore => (),
-        }
-    }
-    desc
-}));
+fn word(input: &str) -> IResult<&str, String> {
+    map(word_ref, |word| word.to_owned())(input)
+}
+
+fn hex_integer(input: &str) -> IResult<&str, i32> {
+    preceded(
+        tag("0x"),
+        map_res(hex_digit1, |s: &str| i32::from_str_radix(s, 16)),
+    )(input)
+}
+
+fn integer(input: &str) -> IResult<&str, i32> {
+    map_res(digit1, |s: &str| s.parse())(input)
+}
+
+fn comment(input: &str) -> IResult<&str, ()> {
+    value(
+        (),
+        tuple((tag("//"), many0(not(line_ending)), opt(line_ending))),
+    )(input)
+}
+
+fn block_comment(input: &str) -> IResult<&str, ()> {
+    value((), tuple((tag("/*"), take_until("*/"), tag("*/"))))(input)
+}
+
+fn string(input: &str) -> IResult<&str, String> {
+    map(
+        delimited(tag("\""), take_until("\""), tag("\"")),
+        |s: &str| s.to_owned(),
+    )(input)
+}
+
+// word break: multispace or comment
+fn br(input: &str) -> IResult<&str, ()> {
+    alt((value((), multispace1), comment, block_comment))(input)
+}
+
+fn syntax(input: &str) -> IResult<&str, Syntax> {
+    delimited(
+        tuple((tag("syntax"), many0(br), tag("="), many0(br))),
+        alt((
+            value(Syntax::Proto2, tag("\"proto2\"")),
+            value(Syntax::Proto3, tag("\"proto3\"")),
+        )),
+        pair(many0(br), tag(";")),
+    )(input)
+}
+
+fn import(input: &str) -> IResult<&str, PathBuf> {
+    delimited(
+        pair(tag("import"), many1(br)),
+        map(string, PathBuf::from),
+        pair(many0(br), tag(";")),
+    )(input)
+}
+
+fn package(input: &str) -> IResult<&str, String> {
+    delimited(
+        pair(tag("package"), many1(br)),
+        word,
+        pair(many0(br), tag(";")),
+    )(input)
+}
+
+fn extensions(input: &str) -> IResult<&str, ()> {
+    value((), delimited(tag("extensions"), take_until(";"), tag(";")))(input)
+}
+
+fn num_range(input: &str) -> IResult<&str, Vec<i32>> {
+    map(
+        separated_pair(integer, tuple((many1(br), tag("to"), many1(br))), integer),
+        |(from_, to)| (from_..=to).collect(),
+    )(input)
+}
+
+fn reserved_nums(input: &str) -> IResult<&str, Vec<i32>> {
+    map(
+        delimited(
+            pair(tag("reserved"), many1(br)),
+            separated_list1(
+                tuple((many0(br), tag(","), many0(br))),
+                alt((num_range, map(integer, |i| vec![i]))),
+            ),
+            pair(many0(br), tag(";")),
+        ),
+        |nums| nums.into_iter().flat_map(|v| v.into_iter()).collect(),
+    )(input)
+}
+
+fn reserved_names(input: &str) -> IResult<&str, Vec<String>> {
+    delimited(
+        pair(tag("reserved"), many1(br)),
+        separated_list1(tuple((many0(br), tag(","), many0(br))), string),
+        pair(many0(br), tag(";")),
+    )(input)
+}
+
+fn key_val(input: &str) -> IResult<&str, (&str, &str)> {
+    delimited(
+        pair(tag("["), many0(br)),
+        separated_pair(
+            word_ref,
+            delimited(many0(br), tag("="), many0(br)),
+            map(take_until("]"), |v: &str| v.trim()),
+        ),
+        tag("]"),
+    )(input)
+}
+
+fn frequency(input: &str) -> IResult<&str, Frequency> {
+    alt((
+        value(Frequency::Optional, tag("optional")),
+        value(Frequency::Repeated, tag("repeated")),
+        value(Frequency::Required, tag("required")),
+    ))(input)
+}
+
+fn field_type(input: &str) -> IResult<&str, FieldType> {
+    alt((
+        value(FieldType::Int32, tag("int32")),
+        value(FieldType::Int64, tag("int64")),
+        value(FieldType::Uint32, tag("uint32")),
+        value(FieldType::Uint64, tag("uint64")),
+        value(FieldType::Sint32, tag("sint32")),
+        value(FieldType::Sint64, tag("sint64")),
+        value(FieldType::Fixed32, tag("fixed32")),
+        value(FieldType::Sfixed32, tag("sfixed32")),
+        value(FieldType::Fixed64, tag("fixed64")),
+        value(FieldType::Sfixed64, tag("sfixed64")),
+        value(FieldType::Bool, tag("bool")),
+        value(FieldType::StringCow, tag("string")),
+        value(FieldType::BytesCow, tag("bytes")),
+        value(FieldType::Float, tag("float")),
+        value(FieldType::Double, tag("double")),
+        map(map_field, |(k, v)| FieldType::Map(Box::new(k), Box::new(v))),
+        map(word, |w| FieldType::MessageOrEnum(w)),
+    ))(input)
+}
+
+fn map_field(input: &str) -> IResult<&str, (FieldType, FieldType)> {
+    delimited(
+        tuple((tag("map"), many0(br), tag("<"), many0(br))),
+        separated_pair(
+            field_type,
+            delimited(many0(br), tag(","), many0(br)),
+            field_type,
+        ),
+        pair(many0(br), tag(">")),
+    )(input)
+}
+
+fn message_field(input: &str) -> IResult<&str, Field> {
+    map(
+        tuple((
+            opt(terminated(frequency, many1(br))),
+            terminated(field_type, many1(br)),
+            separated_pair(
+                word,
+                delimited(many0(br), tag("="), many0(br)),
+                alt((integer, hex_integer)),
+            ),
+            delimited(many0(br), many0(key_val), pair(many0(br), tag(";"))),
+        )),
+        |(freq, typ, (name, number), key_vals)| Field {
+            name,
+            frequency: freq.unwrap_or(Frequency::Optional),
+            number,
+            default: key_vals.iter().find_map(|&(k, v)| {
+                if k == "default" {
+                    Some(v.to_string())
+                } else {
+                    None
+                }
+            }),
+            packed: key_vals.iter().find_map(|&(k, v)| {
+                if k == "packed" {
+                    Some(v.parse().expect("Cannot parse Packed value"))
+                } else {
+                    None
+                }
+            }),
+            boxed: false,
+            typ,
+            deprecated: key_vals
+                .iter()
+                .find_map(|&(k, v)| {
+                    if k == "deprecated" {
+                        Some(v.parse().expect("Cannot parse Deprecated value"))
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(false),
+        },
+    )(input)
+}
+
+fn one_of(input: &str) -> IResult<&str, OneOf> {
+    map(
+        pair(
+            preceded(pair(tag("oneof"), many1(br)), word),
+            delimited(
+                pair(many0(br), tag("{")),
+                many1(delimited(many0(br), message_field, many0(br))),
+                tag("}"),
+            ),
+        ),
+        |(name, fields)| OneOf {
+            name,
+            fields,
+            package: "".to_string(),
+            module: "".to_string(),
+            imported: false,
+        },
+    )(input)
+}
+
+fn rpc_function_declaration(input: &str) -> IResult<&str, RpcFunctionDeclaration> {
+    map(
+        tuple((
+            delimited(pair(tag("rpc"), many1(br)), word, many0(br)),
+            delimited(pair(tag("("), many0(br)), word, pair(many0(br), tag(")"))),
+            delimited(
+                tuple((many1(br), tag("returns"), many0(br), tag("("), many0(br))),
+                word,
+                pair(many0(br), tag(")")),
+            ),
+            preceded(
+                many0(br),
+                alt((
+                    value(
+                        (),
+                        delimited(
+                            pair(tag("{"), many0(br)),
+                            many0(alt((option_ignore, value((), tag(";"))))),
+                            pair(many0(br), tag("}")),
+                        ),
+                    ),
+                    value((), tag(";")),
+                )),
+            ),
+        )),
+        |(name, arg, ret, _)| RpcFunctionDeclaration { name, arg, ret },
+    )(input)
+}
+
+fn rpc_service(input: &str) -> IResult<&str, RpcService> {
+    map(
+        pair(
+            delimited(pair(tag("service"), many1(br)), word, many0(br)),
+            delimited(
+                tag("{"),
+                many0(delimited(many0(br), rpc_function_declaration, many0(br))),
+                tag("}"),
+            ),
+        ),
+        |(service_name, functions)| RpcService {
+            service_name,
+            functions,
+        },
+    )(input)
+}
+
+fn message_event(input: &str) -> IResult<&str, MessageEvent> {
+    alt((
+        map(reserved_nums, |r| MessageEvent::ReservedNums(r)),
+        map(reserved_names, |r| MessageEvent::ReservedNames(r)),
+        map(message_field, |f| MessageEvent::Field(f)),
+        map(message, |m| MessageEvent::Message(m)),
+        map(enumerator, |e| MessageEvent::Enumerator(e)),
+        map(one_of, |o| MessageEvent::OneOf(o)),
+        value(MessageEvent::Ignore, extensions),
+        value(MessageEvent::Ignore, br),
+    ))(input)
+}
+
+fn message(input: &str) -> IResult<&str, Message> {
+    map(
+        terminated(
+            pair(
+                delimited(pair(tag("message"), many1(br)), word, many0(br)),
+                delimited(
+                    tag("{"),
+                    many0(delimited(many0(br), message_event, many0(br))),
+                    tag("}"),
+                ),
+            ),
+            opt(pair(many0(br), tag(";"))),
+        ),
+        |(name, events)| {
+            let mut msg = Message {
+                name,
+                ..Default::default()
+            };
+            for e in events {
+                match e {
+                    MessageEvent::Field(f) => msg.fields.push(f),
+                    MessageEvent::ReservedNums(r) => msg.reserved_nums = Some(r),
+                    MessageEvent::ReservedNames(r) => msg.reserved_names = Some(r),
+                    MessageEvent::Message(m) => msg.messages.push(m),
+                    MessageEvent::Enumerator(e) => msg.enums.push(e),
+                    MessageEvent::OneOf(o) => msg.oneofs.push(o),
+                    MessageEvent::Ignore => (),
+                }
+            }
+            msg
+        },
+    )(input)
+}
+
+fn enum_field(input: &str) -> IResult<&str, (String, i32)> {
+    terminated(
+        separated_pair(
+            word,
+            tuple((many0(br), tag("="), many0(br))),
+            alt((hex_integer, integer)),
+        ),
+        pair(many0(br), tag(";")),
+    )(input)
+}
+
+fn enumerator(input: &str) -> IResult<&str, Enumerator> {
+    map(
+        pair(
+            delimited(pair(tag("enum"), many1(br)), word, many0(br)),
+            delimited(
+                pair(tag("{"), many0(br)),
+                separated_list0(br, enum_field),
+                pair(many0(br), tag("}")),
+            ),
+        ),
+        |(name, fields)| Enumerator {
+            name,
+            fields,
+            ..Default::default()
+        },
+    )(input)
+}
+
+fn option_ignore(input: &str) -> IResult<&str, ()> {
+    value((), delimited(tag("option"), take_until(";"), tag(";")))(input)
+}
+
+pub fn file_descriptor(input: &str) -> IResult<&str, FileDescriptor, nom::error::Error<String>> {
+    map(
+        many0(alt((
+            map(syntax, |s| Event::Syntax(s)),
+            map(import, |i| Event::Import(i)),
+            map(package, |p| Event::Package(p)),
+            map(message, |m| Event::Message(m)),
+            map(enumerator, |e| Event::Enum(e)),
+            map(rpc_service, |r| Event::RpcService(r)),
+            value(Event::Ignore, option_ignore),
+            value(Event::Ignore, br),
+        ))),
+        |events| {
+            let mut desc = FileDescriptor::default();
+            for event in events {
+                match event {
+                    Event::Syntax(s) => desc.syntax = s,
+                    Event::Import(i) => desc.import_paths.push(i),
+                    Event::Package(p) => desc.package = p,
+                    Event::Message(m) => desc.messages.push(m),
+                    Event::Enum(e) => desc.enums.push(e),
+                    Event::RpcService(r) => desc.rpc_services.push(r),
+                    Event::Ignore => (),
+                }
+            }
+            desc
+        },
+    )(input).map_err(|e: nom::Err<nom::error::Error<&str>>| e.to_owned())
+}
 
 #[cfg(test)]
 mod test {
     use super::*;
+
+    use std::path::Path;
 
     #[test]
     fn test_message() {
@@ -491,8 +438,8 @@ mod test {
         repeated MaturityInfo maturitySet = 10;
     }"#;
 
-        let mess = message(msg.as_bytes());
-        if let ::nom::IResult::Done(_, mess) = mess {
+        let mess = message(msg);
+        if let ::nom::IResult::Ok((_, mess)) = mess {
             assert_eq!(10, mess.fields.len());
         }
     }
@@ -506,8 +453,8 @@ mod test {
                 CANCELED          = 3;
     }"#;
 
-        let mess = enumerator(msg.as_bytes());
-        if let ::nom::IResult::Done(_, mess) = mess {
+        let mess = enumerator(msg);
+        if let ::nom::IResult::Ok((_, mess)) = mess {
             assert_eq!(4, mess.fields.len());
         }
     }
@@ -516,8 +463,8 @@ mod test {
     fn test_ignore() {
         let msg = r#"option optimize_for = SPEED;"#;
 
-        match option_ignore(msg.as_bytes()) {
-            ::nom::IResult::Done(_, _) => (),
+        match option_ignore(msg) {
+            ::nom::IResult::Ok(_) => (),
             e => panic!("Expecting done {:?}", e),
         }
     }
@@ -533,7 +480,7 @@ mod test {
         optional ContainerForNested.NestedEnum e = 2;
     }
     "#;
-        let desc = file_descriptor(msg.as_bytes()).to_full_result().unwrap();
+        let desc = file_descriptor(msg).unwrap().1;
         assert_eq!(
             vec![Path::new("test_import_nested_imported_pb.proto")],
             desc.import_paths
@@ -550,7 +497,7 @@ mod test {
         optional ContainerForNested.NestedEnum e = 2;
     }
     "#;
-        let desc = file_descriptor(msg.as_bytes()).to_full_result().unwrap();
+        let desc = file_descriptor(msg).unwrap().1;
         assert_eq!("foo.bar".to_string(), desc.package);
     }
 
@@ -565,8 +512,8 @@ mod test {
         optional b = 1;
     }"#;
 
-        let mess = message(msg.as_bytes());
-        if let ::nom::IResult::Done(_, mess) = mess {
+        let mess = message(msg);
+        if let ::nom::IResult::Ok((_, mess)) = mess {
             assert!(mess.messages.len() == 1);
         }
     }
@@ -578,8 +525,8 @@ mod test {
         optional map<string, int32> b = 1;
     }"#;
 
-        let mess = message(msg.as_bytes());
-        if let ::nom::IResult::Done(_, mess) = mess {
+        let mess = message(msg);
+        if let ::nom::IResult::Ok((_, mess)) = mess {
             assert_eq!(1, mess.fields.len());
             match mess.fields[0].typ {
                 FieldType::Map(ref key, ref value) => match (&**key, &**value) {
@@ -610,8 +557,8 @@ mod test {
         repeated bool a5 = 5;
     }"#;
 
-        let mess = message(msg.as_bytes());
-        if let ::nom::IResult::Done(_, mess) = mess {
+        let mess = message(msg);
+        if let ::nom::IResult::Ok((_, mess)) = mess {
             assert_eq!(1, mess.oneofs.len());
             assert_eq!(3, mess.oneofs[0].fields.len());
         }
@@ -626,8 +573,9 @@ mod test {
        bytes name =2;
     }"#;
 
-        let mess = message(msg.as_bytes());
-        if let ::nom::IResult::Done(_, mess) = mess {
+        let mess = message(msg);
+        dbg!(&mess);
+        if let ::nom::IResult::Ok((_, mess)) = mess {
             assert_eq!(Some(vec![4, 15, 17, 18, 19, 20, 30]), mess.reserved_nums);
             assert_eq!(
                 Some(vec!["foo".to_string(), "bar".to_string()]),
@@ -649,8 +597,8 @@ mod test {
             }
         "#;
 
-        match file_descriptor(msg.as_bytes()) {
-            ::nom::IResult::Done(_, descriptor) => {
+        match file_descriptor(msg) {
+            ::nom::IResult::Ok((_, descriptor)) => {
                 println!("Services found: {:?}", descriptor.rpc_services);
                 let service = &descriptor.rpc_services.get(0).expect("Service not found!");
                 let func0 = service.functions.get(0).expect("Function 0 not returned!");
@@ -675,8 +623,8 @@ mod test {
     fn test_rpc_function() {
         let msg = r#"rpc function_name(Arg) returns (Ret);"#;
 
-        match rpc_function_declaration(msg.as_bytes()) {
-            ::nom::IResult::Done(_, declaration) => {
+        match rpc_function_declaration(msg) {
+            ::nom::IResult::Ok((_, declaration)) => {
                 assert_eq!("function_name", declaration.name);
                 assert_eq!("Arg", declaration.arg);
                 assert_eq!("Ret", declaration.ret);

--- a/pb-rs/src/types.rs
+++ b/pb-rs/src/types.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::fs::File;
-use std::io::{BufReader, BufWriter, Read, Write};
+use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 use log::{debug, warn};
@@ -1893,13 +1893,8 @@ impl FileDescriptor {
 
     /// Opens a proto file, reads it and returns raw parsed data
     pub fn read_proto(in_file: &Path, import_search_path: &[PathBuf]) -> Result<FileDescriptor> {
-        let mut buf = Vec::new();
-        {
-            let f = File::open(in_file)?;
-            let mut reader = BufReader::new(f);
-            reader.read_to_end(&mut buf)?;
-        }
-        let mut desc = file_descriptor(&buf).to_result().map_err(Error::Nom)?;
+        let file = std::fs::read_to_string(in_file)?;
+        let (_, mut desc) = file_descriptor(&file).map_err(|e| Error::Nom(e))?;
         for mut m in &mut desc.messages {
             if m.path.as_os_str().is_empty() {
                 m.path = in_file.to_path_buf();


### PR DESCRIPTION
Nom 3 is a bit old now and I was curious enough to try my hands at modernizing the parser. I've tried to copy the old structure as much as possible but in some cases I simplified it/condensed some functions. All tests and the benchmarks seems to run fine, but this one likely requires a bit more thorough review than my previous uplift.

The one "breaking" change here is that the file is parsed as UTF-8 rather than bytes (but it seems like proto files must be utf-8 anyway https://github.com/protocolbuffers/protobuf/issues/1418).