### PR TITLE
Fix possible UB in reader (#186)

### DIFF
--- a/quick-protobuf/src/reader.rs
+++ b/quick-protobuf/src/reader.rs
@@ -550,10 +550,7 @@ impl Reader {
     /// Creates a new `Reader`
     #[cfg(feature = "std")]
     pub fn from_reader<R: Read>(mut r: R, capacity: usize) -> Result<Reader> {
-        let mut buf = Vec::with_capacity(capacity);
-        unsafe {
-            buf.set_len(capacity);
-        }
+        let mut buf = vec![0; capacity];
         buf.shrink_to_fit();
         r.read_exact(&mut buf)?;
         Ok(Reader::from_bytes(buf))


### PR DESCRIPTION
This fixes the possible undefined behaviour in `Reader::from_reader()` (See #186 ).

This causes a small runtime overhead due to the explicit initialization, but as far as I understood this method is only called by the user explicitly, so it may not matter so much.