### PR TITLE
feat: small improvements to pb-rs arg parsing

### DIFF
--- a/pb-rs/src/main.rs
+++ b/pb-rs/src/main.rs
@@ -47,6 +47,7 @@ fn run() -> Result<(), Error> {
         ).arg(
             Arg::with_name("INPUT")
                 .multiple(true)
+                .required(true)
                 .help("The .proto files used to generate quick-protobuf code")
                 .validator(|x| extension_matches(x, "proto")),
         ).arg(

--- a/pb-rs/src/main.rs
+++ b/pb-rs/src/main.rs
@@ -93,9 +93,9 @@ fn run() -> Result<(), Error> {
                 .help("Generate no_std compliant code"),
         ).arg(
             Arg::with_name("HASHBROWN")
-                .long("hashrown")
+                .long("hashbrown")
                 .required(false)
-                .help("Use hashrown for HashMap implementation"),
+                .help("Use the hashbrown crate as the HashMap implementation"),
         ).arg(
             Arg::with_name("GEN_INFO")
                 .long("gen-info")


### PR DESCRIPTION
Two small improvements to the arg parser in `pb-rs`:
 * spell `hashbrown` correctly, to save me googling what `hashrown` is and getting really confused. Technically this is a breaking change.
 * Mark `input` as required, so `pb-rs` with no args is a bit more helpful:

Before:

```
pb-rs fatal error No .proto file provided
```

After:

```
error: The following required arguments were not provided:
    <INPUT>...

USAGE:
    pb-rs [FLAGS] [OPTIONS] <INPUT>...

For more information try --help
```

It's not ideal, but it's a bit more comforting to me, who is used to `clap` output?