### PR TITLE
fix: .. the parser

### DIFF
--- a/pb-rs/src/errors.rs
+++ b/pb-rs/src/errors.rs
@@ -7,6 +7,8 @@ pub enum Error {
     Io(io::Error),
     /// Nom Error
     Nom(nom::Err<nom::error::Error<String>>),
+    /// Nom's other failure case; giving up in the middle of a file
+    TrailingGarbage(String),
     /// No .proto file provided
     NoProto,
     /// Cannot read input file
@@ -59,6 +61,7 @@ impl std::fmt::Display for Error {
         match self {
             Error::Io(e) => write!(f, "{}", e),
             Error::Nom(e) => write!(f, "{}", e),
+            Error::TrailingGarbage(s) => write!(f, "parsing abandoned near: {:?}", s),
             Error::NoProto => write!(f, "No .proto file provided"),
             Error::InputFile(file) => write!(f, "Cannot read input file '{}'", file),
             Error::OutputFile(file) => write!(f, "Cannot read output file '{}'", file),

--- a/pb-rs/src/parser.rs
+++ b/pb-rs/src/parser.rs
@@ -370,7 +370,7 @@ fn enumerator(input: &str) -> IResult<&str, Enumerator> {
             delimited(pair(tag("enum"), many1(br)), word, many0(br)),
             delimited(
                 pair(tag("{"), many0(br)),
-                separated_list0(br, enum_field),
+                separated_list0(many0(br), enum_field),
                 pair(many0(br), tag("}")),
             ),
         ),
@@ -617,6 +617,18 @@ mod test {
         } else {
             panic!("Could not parse reserved fields message");
         }
+    }
+
+    #[test]
+    fn enum_comments() {
+        let msg = r#"enum Turn {
+            UP = 1;
+            // for what?
+            // for what, you ask?
+            DOWN = 2;
+          }"#;
+        let en = assert_complete(enumerator(msg));
+        assert_eq!(2, en.fields.len());
     }
 
     #[test]

--- a/pb-rs/src/parser.rs
+++ b/pb-rs/src/parser.rs
@@ -366,13 +366,16 @@ fn enum_field(input: &str) -> IResult<&str, (String, i32)> {
 
 fn enumerator(input: &str) -> IResult<&str, Enumerator> {
     map(
-        pair(
-            delimited(pair(tag("enum"), many1(br)), word, many0(br)),
-            delimited(
-                pair(tag("{"), many0(br)),
-                separated_list0(many0(br), enum_field),
-                pair(many0(br), tag("}")),
+        terminated(
+            pair(
+                delimited(pair(tag("enum"), many1(br)), word, many0(br)),
+                delimited(
+                    pair(tag("{"), many0(br)),
+                    separated_list0(many0(br), enum_field),
+                    pair(many0(br), tag("}")),
+                ),
             ),
+            opt(pair(many0(br), tag(";"))),
         ),
         |(name, fields)| Enumerator {
             name,
@@ -629,6 +632,13 @@ mod test {
           }"#;
         let en = assert_complete(enumerator(msg));
         assert_eq!(2, en.fields.len());
+    }
+
+    #[test]
+    fn enum_semi() {
+        let msg = r#"message Foo { enum Bar { BAZ = 1; }; Bar boop = 1; }"#;
+        let desc = assert_desc(msg);
+        assert_eq!(1, desc.messages.len());
     }
 
     #[test]

--- a/pb-rs/src/parser.rs
+++ b/pb-rs/src/parser.rs
@@ -327,7 +327,7 @@ fn message(input: &str) -> IResult<&str, Message> {
                 delimited(
                     tag("{"),
                     many0(delimited(many0(br), message_event, many0(br))),
-                    tag("}"),
+                    preceded(many0(br), tag("}")),
                 ),
             ),
             opt(pair(many0(br), tag(";"))),
@@ -442,6 +442,14 @@ mod test {
         if let ::nom::IResult::Ok((_, mess)) = mess {
             assert_eq!(10, mess.fields.len());
         }
+    }
+
+    #[test]
+    fn empty_message() {
+        let (rem, mess) = message("message Vec { }").expect("parse success");
+        assert_eq!("", rem);
+        assert_eq!("Vec", mess.name);
+        assert_eq!(0, mess.fields.len());
     }
 
     #[test]

--- a/pb-rs/src/types.rs
+++ b/pb-rs/src/types.rs
@@ -1926,7 +1926,11 @@ impl FileDescriptor {
     /// Opens a proto file, reads it and returns raw parsed data
     pub fn read_proto(in_file: &Path, import_search_path: &[PathBuf]) -> Result<FileDescriptor> {
         let file = std::fs::read_to_string(in_file)?;
-        let (_, mut desc) = file_descriptor(&file).map_err(|e| Error::Nom(e))?;
+        let (rem, mut desc) = file_descriptor(&file).map_err(|e| Error::Nom(e))?;
+        let rem = rem.trim();
+        if !rem.is_empty() {
+            return Err(Error::TrailingGarbage(rem.chars().take(50).collect()));
+        }
         for mut m in &mut desc.messages {
             if m.path.as_os_str().is_empty() {
                 m.path = in_file.to_path_buf();


### PR DESCRIPTION
The new parser has broken `./generate_modules.sh` in a number of places.

As a first ... pass, fix the parser to actually error on rejections, then fix all of the `.proto` files the parser just rejects, due to omissions or bugs.

 * single-line comment parser was accepting no comments, because `not` doesn't seem to work like that
 * missed whitespace handling for ` }` in e.g. `message`.
 * enums with multiple lines of comments between items
 * enums with trailing semis