### PR TITLE
feat(pb-rs): --skip-write

### DIFF
--- a/pb-rs/Cargo.toml
+++ b/pb-rs/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 nom = "7"
 log = "0.4.4"
 clap = { version = "2.33.1", optional = true }
-env_logger = { version = "0.7.1", optional = true }
+env_logger = { version = "0.9.0", optional = true }
 
 [dev-dependencies]
 walkdir = "2.3.1"

--- a/pb-rs/src/errors.rs
+++ b/pb-rs/src/errors.rs
@@ -7,6 +7,8 @@ pub enum Error {
     Io(io::Error),
     /// Nom Error
     Nom(nom::Err<nom::error::Error<String>>),
+    /// Nom's other failure case; giving up in the middle of a file
+    TrailingGarbage(String),
     /// No .proto file provided
     NoProto,
     /// Cannot read input file
@@ -59,6 +61,7 @@ impl std::fmt::Display for Error {
         match self {
             Error::Io(e) => write!(f, "{}", e),
             Error::Nom(e) => write!(f, "{}", e),
+            Error::TrailingGarbage(s) => write!(f, "parsing abandoned near: {:?}", s),
             Error::NoProto => write!(f, "No .proto file provided"),
             Error::InputFile(file) => write!(f, "Cannot read input file '{}'", file),
             Error::OutputFile(file) => write!(f, "Cannot read output file '{}'", file),

--- a/pb-rs/src/lib.rs
+++ b/pb-rs/src/lib.rs
@@ -61,6 +61,7 @@ pub struct ConfigBuilder {
     owned: bool,
     nostd: bool,
     hashbrown: bool,
+    gen_write: bool,
     gen_info: bool,
     add_deprecated_fields: bool,
 }
@@ -183,6 +184,12 @@ impl ConfigBuilder {
         self
     }
 
+    /// Generate `MessageWrite` implementations
+    pub fn gen_write(mut self, val: bool) -> Self {
+        self.gen_write = val;
+        self
+    }
+
     /// Generate `MessageInfo` implementations
     pub fn gen_info(mut self, val: bool) -> Self {
         self.gen_info = val;
@@ -226,6 +233,7 @@ impl ConfigBuilder {
                     owned: self.owned,
                     nostd: self.nostd,
                     hashbrown: self.hashbrown,
+                    gen_write: self.gen_write,
                     gen_info: self.gen_info,
                     add_deprecated_fields: self.add_deprecated_fields,
                 }

--- a/pb-rs/src/main.rs
+++ b/pb-rs/src/main.rs
@@ -97,6 +97,11 @@ fn run() -> Result<(), Error> {
                 .required(false)
                 .help("Use hashrown for HashMap implementation"),
         ).arg(
+            Arg::with_name("SKIP_WRITE")
+                .long("skip-write")
+                .required(false)
+                .help("Skip MessageWrite implementations")
+        ).arg(
             Arg::with_name("GEN_INFO")
                 .long("gen-info")
                 .required(false)
@@ -134,6 +139,7 @@ fn run() -> Result<(), Error> {
     .custom_struct_derive(custom_struct_derive)
     .nostd(matches.is_present("NOSTD"))
     .hashbrown(matches.is_present("HASHBROWN"))
+    .gen_write(!matches.is_present("SKIP_WRITE"))
     .gen_info(matches.is_present("GEN_INFO"))
     .custom_repr(custom_repr)
     .owned(matches.is_present("OWNED"))

--- a/pb-rs/src/parser.rs
+++ b/pb-rs/src/parser.rs
@@ -370,7 +370,7 @@ fn enumerator(input: &str) -> IResult<&str, Enumerator> {
             delimited(pair(tag("enum"), many1(br)), word, many0(br)),
             delimited(
                 pair(tag("{"), many0(br)),
-                separated_list0(br, enum_field),
+                separated_list0(many0(br), enum_field),
                 pair(many0(br), tag("}")),
             ),
         ),
@@ -617,6 +617,18 @@ mod test {
         } else {
             panic!("Could not parse reserved fields message");
         }
+    }
+
+    #[test]
+    fn enum_comments() {
+        let msg = r#"enum Turn {
+            UP = 1;
+            // for what?
+            // for what, you ask?
+            DOWN = 2;
+          }"#;
+        let en = assert_complete(enumerator(msg));
+        assert_eq!(2, en.fields.len());
     }
 
     #[test]

--- a/pb-rs/src/parser.rs
+++ b/pb-rs/src/parser.rs
@@ -327,7 +327,7 @@ fn message(input: &str) -> IResult<&str, Message> {
                 delimited(
                     tag("{"),
                     many0(delimited(many0(br), message_event, many0(br))),
-                    tag("}"),
+                    preceded(many0(br), tag("}")),
                 ),
             ),
             opt(pair(many0(br), tag(";"))),
@@ -442,6 +442,14 @@ mod test {
         if let ::nom::IResult::Ok((_, mess)) = mess {
             assert_eq!(10, mess.fields.len());
         }
+    }
+
+    #[test]
+    fn empty_message() {
+        let (rem, mess) = message("message Vec { }").expect("parse success");
+        assert_eq!("", rem);
+        assert_eq!("Vec", mess.name);
+        assert_eq!(0, mess.fields.len());
     }
 
     #[test]

--- a/pb-rs/src/types.rs
+++ b/pb-rs/src/types.rs
@@ -945,7 +945,9 @@ impl Message {
         writeln!(w)?;
         self.write_impl_message_read(w, desc, config)?;
         writeln!(w)?;
-        self.write_impl_message_write(w, desc, config)?;
+        if config.gen_write {
+            self.write_impl_message_write(w, desc, config)?;
+        }
 
         if config.gen_info {
             self.write_impl_message_info(w, desc, config)?;
@@ -1813,6 +1815,7 @@ pub struct Config {
     pub owned: bool,
     pub nostd: bool,
     pub hashbrown: bool,
+    pub gen_write: bool,
     pub gen_info: bool,
     pub add_deprecated_fields: bool,
 }

--- a/pb-rs/src/types.rs
+++ b/pb-rs/src/types.rs
@@ -1926,7 +1926,11 @@ impl FileDescriptor {
     /// Opens a proto file, reads it and returns raw parsed data
     pub fn read_proto(in_file: &Path, import_search_path: &[PathBuf]) -> Result<FileDescriptor> {
         let file = std::fs::read_to_string(in_file)?;
-        let (_, mut desc) = file_descriptor(&file).map_err(|e| Error::Nom(e))?;
+        let (rem, mut desc) = file_descriptor(&file).map_err(|e| Error::Nom(e))?;
+        let rem = rem.trim();
+        if !rem.is_empty() {
+            return Err(Error::TrailingGarbage(rem.chars().take(50).collect()));
+        }
         for mut m in &mut desc.messages {
             if m.path.as_os_str().is_empty() {
                 m.path = in_file.to_path_buf();

--- a/perftest/Cargo.toml
+++ b/perftest/Cargo.toml
@@ -9,7 +9,8 @@ edition = "2021"
 [dependencies]
 protobuf = "2.25.2"
 quick-protobuf = { path = "../quick-protobuf" }
-rand = "0.5.5"
+rand = "0.8"
+rand_xoshiro = "0.6"
 prost = "0.9.0"
 bytes = "1"
 
@@ -18,3 +19,6 @@ protobuf-codegen-pure = "2.25.2"
 pb-rs = { path = "../pb-rs" }
 prost-build = "0.9.0"
 [features]
+
+[profile.release]
+lto = true

--- a/perftest/build.rs
+++ b/perftest/build.rs
@@ -61,6 +61,7 @@ fn main() {
         owned: false,
         hashbrown: false,
         nostd: false,
+        gen_write: true,
         gen_info: false,
         add_deprecated_fields: false,
     };

--- a/perftest/src/main.rs
+++ b/perftest/src/main.rs
@@ -1,4 +1,3 @@
-use rand::{rngs::SmallRng, Rng, SeedableRng};
 use std::default::Default;
 use std::fmt::Debug;
 use std::fs::File;
@@ -12,6 +11,8 @@ use perftest_data_quick::PerftestData as QuickPerftestData;
 
 use prost::Message as ProstMessage;
 use protobuf::Message;
+use rand::{Rng, SeedableRng};
+use rand_xoshiro::Xoshiro256PlusPlus;
 use quick_protobuf::{BytesReader, MessageRead, MessageWrite, Reader, Writer};
 
 mod perftest_data;
@@ -20,8 +21,9 @@ mod perftest_data_quick {
     include!(concat!(env!("OUT_DIR"), "/perftest_data_quick.rs"));
 }
 
-const SEED: [u8; 16] = [
+const SEED: [u8; 32] = [
     10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160,
+    15, 25, 35, 45, 55, 65, 75, 85, 95, 105, 115, 125, 135, 145, 155, 165,
 ];
 
 fn measure<R: Debug + PartialEq, F: FnMut() -> R>(iter: u128, mut f: F, check: Option<&R>) -> u128 {
@@ -41,12 +43,12 @@ impl TestRunner {
     fn run_test<M: Clone + Message + Default + PartialEq>(&self, data: &[M]) -> [u128; 4] {
         let mut a = [0; 4];
 
-        let mut rng = SmallRng::from_seed(SEED);
+        let mut rng = Xoshiro256PlusPlus::from_seed(SEED);
         let mut random_data = Vec::new();
 
         let mut total_size = 0;
         while total_size < self.data_size {
-            let item = data[rng.gen_range(0, data.len())].clone();
+            let item = data[rng.gen_range(0..data.len())].clone();
             total_size += item.compute_size();
             random_data.push(item);
         }
@@ -117,12 +119,12 @@ impl TestRunner {
     {
         let mut b = [0; 4];
 
-        let mut rng = SmallRng::from_seed(SEED);
+        let mut rng = Xoshiro256PlusPlus::from_seed(SEED);
         let mut random_data: Vec<M> = Vec::new();
 
         let mut total_size = 0;
         while total_size < self.data_size {
-            let ref item = data[rng.gen_range(0, data.len())];
+            let ref item = data[rng.gen_range(0..data.len())];
             random_data.push(item.clone());
             total_size += item.get_size() as u32;
         }
@@ -178,12 +180,12 @@ impl TestRunner {
     fn quick_run_test_strings(&self, data: &[perftest_data_quick::TestStrings]) -> [u128; 4] {
         let mut b = [0; 4];
 
-        let mut rng = SmallRng::from_seed(SEED);
+        let mut rng = Xoshiro256PlusPlus::from_seed(SEED);
         let mut random_data = Vec::new();
 
         let mut total_size = 0;
         while total_size < self.data_size {
-            let ref item = data[rng.gen_range(0, data.len())];
+            let ref item = data[rng.gen_range(0..data.len())];
             random_data.push(item.clone());
             total_size += item.get_size() as u32;
         }
@@ -230,12 +232,12 @@ impl TestRunner {
     fn quick_run_test_bytes(&self, data: &[perftest_data_quick::TestBytes]) -> [u128; 4] {
         let mut b = [0; 4];
 
-        let mut rng = SmallRng::from_seed(SEED);
+        let mut rng = Xoshiro256PlusPlus::from_seed(SEED);
         let mut random_data = Vec::new();
 
         let mut total_size = 0;
         while total_size < self.data_size {
-            let ref item = data[rng.gen_range(0, data.len())];
+            let ref item = data[rng.gen_range(0..data.len())];
             random_data.push(item.clone());
             total_size += item.get_size() as u32;
         }
@@ -285,12 +287,12 @@ impl TestRunner {
     ) -> [u128; 4] {
         let mut c = [0; 4];
 
-        let mut rng = SmallRng::from_seed(SEED);
+        let mut rng = Xoshiro256PlusPlus::from_seed(SEED);
         let mut random_data: Vec<M> = Vec::new();
 
         let mut total_size = 0;
         while total_size < self.data_size {
-            let ref item = data[rng.gen_range(0, data.len())];
+            let ref item = data[rng.gen_range(0..data.len())];
             random_data.push(item.clone());
             total_size += item.encoded_len() as u32;
         }


### PR DESCRIPTION
An option to not generate `MessageWrite` implementations, which I don't need and don't want. Not important at all.

Follows #206 for no apparent reason.