### PR TITLE
Serialize/Deserialize functions without length prefix

### DIFF
--- a/quick-protobuf/src/lib.rs
+++ b/quick-protobuf/src/lib.rs
@@ -14,8 +14,10 @@ pub mod writer;
 
 pub use crate::errors::{Error, Result};
 pub use crate::message::{MessageInfo, MessageRead, MessageWrite};
-pub use crate::reader::{deserialize_from_slice, BytesReader};
-pub use crate::writer::{serialize_into_slice, BytesWriter, Writer, WriterBackend};
+pub use crate::reader::{deserialize_from_slice, deserialize_from_slice_without_len, BytesReader};
+pub use crate::writer::{
+    serialize_into_slice, serialize_into_slice_without_len, BytesWriter, Writer, WriterBackend,
+};
 
 #[cfg(feature = "std")]
 pub use crate::reader::Reader;

--- a/quick-protobuf/src/reader.rs
+++ b/quick-protobuf/src/reader.rs
@@ -413,6 +413,18 @@ impl BytesReader {
 
     /// Reads a nested message
     ///
+    /// The length is computed from the size of the message `bytes`
+    #[cfg_attr(std, inline)]
+    pub fn read_message_without_len<'a, M>(&mut self, bytes: &'a [u8]) -> Result<M>
+    where
+        M: MessageRead<'a>,
+    {
+        let len = bytes.len();
+        self.read_len(bytes, M::from_reader, len)
+    }
+
+    /// Reads a nested message
+    ///
     /// Reads just the message and does not try to read it's size first.
     ///  * 'len' - The length of the message to be read.
     #[cfg_attr(std, inline)]
@@ -600,9 +612,17 @@ impl Reader {
 }
 
 /// Deserialize a `MessageRead from a `&[u8]`
+///
+/// Must be prefixed with the length of the message
 pub fn deserialize_from_slice<'a, M: MessageRead<'a>>(bytes: &'a [u8]) -> Result<M> {
     let mut reader = BytesReader::from_bytes(&bytes);
     reader.read_message::<M>(&bytes)
+}
+
+/// Deserialize a `MessageRead from a `&[u8]` without a length prefix
+pub fn deserialize_from_slice_without_len<'a, M: MessageRead<'a>>(bytes: &'a [u8]) -> Result<M> {
+    let mut reader = BytesReader::from_bytes(&bytes);
+    reader.read_message_without_len::<M>(&bytes)
 }
 
 #[test]

--- a/quick-protobuf/tests/write_read.rs
+++ b/quick-protobuf/tests/write_read.rs
@@ -1,7 +1,10 @@
 extern crate quick_protobuf;
 
 use quick_protobuf::sizeofs::*;
-use quick_protobuf::{deserialize_from_slice, serialize_into_slice, serialize_into_vec};
+use quick_protobuf::{
+    deserialize_from_slice, deserialize_from_slice_without_len, serialize_into_slice,
+    serialize_into_slice_without_len, serialize_into_vec,
+};
 use quick_protobuf::{
     BytesReader, MessageRead, MessageWrite, Reader, Result, Writer, WriterBackend,
 };
@@ -164,6 +167,21 @@ fn wr_message_slice() {
     serialize_into_slice(&v, &mut buf).unwrap();
 
     assert_eq!(v, deserialize_from_slice(&buf).unwrap());
+}
+
+#[test]
+fn wr_message_slice_without_len() {
+    let original = TestMessage {
+        id: Some(63),
+        val: vec![53, 5, 76, 743, 23, 753],
+    };
+
+    let len = original.get_size();
+    let mut serialized = vec![0u8; len];
+    serialize_into_slice_without_len(&original, &mut serialized).unwrap();
+
+    let deserialized = deserialize_from_slice_without_len(&serialized).unwrap();
+    assert_eq!(original, deserialized);
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Default)]


### PR DESCRIPTION
Following: https://github.com/tafia/quick-protobuf/issues/202

This PR adds the following:

- [x] Message writer without prefixing a length
- [x] Slice serializer without prefixing a length
- [x] Reading messages that **aren't** prefixed with a length 
- [x] Reading slices that **aren't** prefixed with a length
- [x] Read/Write test for all the above implementations