### PR TITLE
Fix read unknown overflow

### DIFF
--- a/quick-protobuf/src/errors.rs
+++ b/quick-protobuf/src/errors.rs
@@ -26,6 +26,8 @@ pub enum Error {
     UnexpectedEndOfBuffer,
     /// The supplied output buffer is not large enough to serialize the message
     OutputBufferTooSmall,
+    /// Input requires larger than usize offsets
+    SizeOverflow,
 }
 
 /// A wrapper for `Result<T, Error>`
@@ -84,6 +86,7 @@ impl core::fmt::Display for Error {
             Error::Map(tag) => write!(f, "Unexpected map tag: '{}', expecting 1 or 2", tag),
             Error::UnexpectedEndOfBuffer => write!(f, "Unexpected end of buffer"),
             Error::OutputBufferTooSmall => write!(f, "Output buffer too small"),
+            Error::SizeOverflow => write!(f, "Input contained too large length"),
         }
     }
 }

--- a/quick-protobuf/src/reader.rs
+++ b/quick-protobuf/src/reader.rs
@@ -455,18 +455,18 @@ impl BytesReader {
     /// Reads unknown data, based on its tag value (which itself gives us the wire_type value)
     #[cfg_attr(std, inline)]
     pub fn read_unknown(&mut self, bytes: &[u8], tag_value: u32) -> Result<()> {
-        match (tag_value & 0x7) as u8 {
+        use std::convert::TryFrom;
+
+        let offset = match (tag_value & 0x7) as u8 {
             WIRE_TYPE_VARINT => {
                 self.read_varint64(bytes)?;
+                return Ok(());
             }
-            WIRE_TYPE_FIXED64 => self.start += 8,
-            WIRE_TYPE_FIXED32 => self.start += 4,
+            WIRE_TYPE_FIXED64 => 8,
+            WIRE_TYPE_FIXED32 => 4,
             WIRE_TYPE_LENGTH_DELIMITED => {
-                let len = self.read_varint64(bytes)? as usize;
-                self.start = self
-                    .start
-                    .checked_add(len)
-                    .ok_or(Error::UnexpectedEndOfBuffer)?;
+                // FIXME: overflow here as well
+                self.read_varint64(bytes)?
             }
             WIRE_TYPE_START_GROUP | WIRE_TYPE_END_GROUP => {
                 return Err(Error::Deprecated("group"));
@@ -474,7 +474,12 @@ impl BytesReader {
             t => {
                 return Err(Error::UnknownWireType(t));
             }
-        }
+        };
+
+        // make the safe conversion to platform dependent usize
+        let offset = usize::try_from(offset).map_err(|_| Error::SizeOverflow)?;
+
+        self.start = self.start.checked_add(offset).ok_or(Error::SizeOverflow)?;
         Ok(())
     }
 
@@ -632,5 +637,5 @@ fn read_size_overflowing_unknown() {
     assert_eq!(r.next_tag(bytes).unwrap(), 4730);
     let e = r.read_unknown(bytes, 4730).unwrap_err();
 
-    assert!(matches!(e, Error::UnexpectedEndOfBuffer), "{:?}", e);
+    assert!(matches!(e, Error::SizeOverflow), "{:?}", e);
 }

--- a/quick-protobuf/src/reader.rs
+++ b/quick-protobuf/src/reader.rs
@@ -463,7 +463,10 @@ impl BytesReader {
             WIRE_TYPE_FIXED32 => self.start += 4,
             WIRE_TYPE_LENGTH_DELIMITED => {
                 let len = self.read_varint64(bytes)? as usize;
-                self.start += len;
+                self.start = self
+                    .start
+                    .checked_add(len)
+                    .ok_or(Error::UnexpectedEndOfBuffer)?;
             }
             WIRE_TYPE_START_GROUP | WIRE_TYPE_END_GROUP => {
                 return Err(Error::Deprecated("group"));


### PR DESCRIPTION
Found this overflow by fuzzing one of the crates using quick-protobuf. This fixes an error related to `BytesReader::read_unknown` that was the first fuzzing error I found.

My branch is based on 75a0517 which is not the most recent master, as the nom upgrade seems to have broken the testing.

I can follow up with a simple fuzzing target in the PR.