### PR TITLE
test: add fuzzing to quick-protobuf

### DIFF
--- a/quick-protobuf/fuzz/.gitignore
+++ b/quick-protobuf/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/quick-protobuf/fuzz/Cargo.toml
+++ b/quick-protobuf/fuzz/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "quick-protobuf-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[profile.dev]
+debug = 2
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.quick-protobuf]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "foomessage"
+path = "fuzz_targets/foomessage.rs"
+test = false
+doc = false

--- a/quick-protobuf/fuzz/fuzz_targets/foomessage.rs
+++ b/quick-protobuf/fuzz/fuzz_targets/foomessage.rs
@@ -1,0 +1,11 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use quick_protobuf::{BytesReader, MessageRead};
+
+fuzz_target!(|data: &[u8]| {
+    let mut r = BytesReader::from_bytes(data);
+    let _ = pb_rs::data_types::FooMessage::from_reader(&mut r, data);
+});
+
+#[path = "../../examples/pb_rs/mod.rs"]
+mod pb_rs;


### PR DESCRIPTION
single simple fuzz target based on the extensive quick-protobuf/examples/pb_rs' FooMessage.

you will need nightly rust compiler to run the fuzz targets, recommended usage with rustup: `cargo +nightly fuzz run foomessage`

using this fuzz_target it's quite tricky to reproduce the crashes. I was so far lucky with tracing the method invocations but that is quite a lot of work.