### PR TITLE
strip comments in protobuf before parsing

### DIFF
--- a/pb-rs/Cargo.toml
+++ b/pb-rs/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 nom = "7"
 log = "0.4.4"
 clap = { version = "2.33.1", optional = true }
+comment-strip = "0.1.3"
 env_logger = { version = "0.7.1", optional = true }
 
 [dev-dependencies]

--- a/perftest/src/perftest_data.proto
+++ b/perftest/src/perftest_data.proto
@@ -2,7 +2,13 @@ syntax = "proto2";
 
 package perftest_data;
 
+// Single line comment
+
 message Test1 {
+/* Multi
+   line
+   comment
+*/
     optional int32 value = 1;
 }
 


### PR DESCRIPTION
Protobuf allows c/c++ style comments, but the parser chokes on these. The comment-strip package can strip these out before we continue processing. Tested with perftest_data.proto, which now has additional comments.