### PR TITLE
negative int32 sign-extended too much?

### DIFF
--- a/pb-rs/src/types.rs
+++ b/pb-rs/src/types.rs
@@ -368,11 +368,11 @@ impl FieldType {
     fn get_size(&self, s: &str) -> String {
         match *self {
             FieldType::Int32
-            | FieldType::Int64
+            | FieldType::Enum(_) => format!("sizeof_varint(*({}) as u32 as u64)", s),
+            FieldType::Int64
             | FieldType::Uint32
             | FieldType::Uint64
-            | FieldType::Bool
-            | FieldType::Enum(_) => format!("sizeof_varint(*({}) as u64)", s),
+            | FieldType::Bool => format!("sizeof_varint(*({}) as u64)", s),
             FieldType::Sint32 => format!("sizeof_sint32(*({}))", s),
             FieldType::Sint64 => format!("sizeof_sint64(*({}))", s),
 

--- a/quick-protobuf/examples/pb_rs/data_types.rs
+++ b/quick-protobuf/examples/pb_rs/data_types.rs
@@ -70,7 +70,7 @@ impl<'a> MessageRead<'a> for BarMessage {
 impl MessageWrite for BarMessage {
     fn get_size(&self) -> usize {
         0
-        + 1 + sizeof_varint(*(&self.b_required_int32) as u64)
+        + 1 + sizeof_varint(*(&self.b_required_int32) as u32 as u64)
     }
 
     fn write_message<W: WriterBackend>(&self, w: &mut Writer<W>) -> Result<()> {
@@ -162,14 +162,14 @@ impl<'a> MessageRead<'a> for FooMessage<'a> {
 impl<'a> MessageWrite for FooMessage<'a> {
     fn get_size(&self) -> usize {
         0
-        + self.f_int32.as_ref().map_or(0, |m| 1 + sizeof_varint(*(m) as u64))
+        + self.f_int32.as_ref().map_or(0, |m| 1 + sizeof_varint(*(m) as u32 as u64))
         + self.f_int64.as_ref().map_or(0, |m| 1 + sizeof_varint(*(m) as u64))
         + self.f_uint32.as_ref().map_or(0, |m| 1 + sizeof_varint(*(m) as u64))
         + self.f_uint64.as_ref().map_or(0, |m| 1 + sizeof_varint(*(m) as u64))
         + self.f_sint32.as_ref().map_or(0, |m| 1 + sizeof_sint32(*(m)))
         + if self.f_sint64 == 4i64 { 0 } else { 1 + sizeof_sint64(*(&self.f_sint64)) }
         + if self.f_bool == true { 0 } else { 1 + sizeof_varint(*(&self.f_bool) as u64) }
-        + self.f_FooEnum.as_ref().map_or(0, |m| 1 + sizeof_varint(*(m) as u64))
+        + self.f_FooEnum.as_ref().map_or(0, |m| 1 + sizeof_varint(*(m) as u32 as u64))
         + self.f_fixed64.as_ref().map_or(0, |_| 1 + 8)
         + self.f_sfixed64.as_ref().map_or(0, |_| 1 + 8)
         + if self.f_fixed32 == 0u32 { 0 } else { 1 + 4 }
@@ -180,16 +180,16 @@ impl<'a> MessageWrite for FooMessage<'a> {
         + self.f_string.as_ref().map_or(0, |m| 2 + sizeof_len((m).len()))
         + self.f_self_message.as_ref().map_or(0, |m| 2 + sizeof_len((m).get_size()))
         + self.f_bar_message.as_ref().map_or(0, |m| 2 + sizeof_len((m).get_size()))
-        + self.f_repeated_int32.iter().map(|s| 2 + sizeof_varint(*(s) as u64)).sum::<usize>()
-        + if self.f_repeated_packed_int32.is_empty() { 0 } else { 2 + sizeof_len(self.f_repeated_packed_int32.iter().map(|s| sizeof_varint(*(s) as u64)).sum::<usize>()) }
+        + self.f_repeated_int32.iter().map(|s| 2 + sizeof_varint(*(s) as u32 as u64)).sum::<usize>()
+        + if self.f_repeated_packed_int32.is_empty() { 0 } else { 2 + sizeof_len(self.f_repeated_packed_int32.iter().map(|s| sizeof_varint(*(s) as u32 as u64)).sum::<usize>()) }
         + if self.f_repeated_packed_float.is_empty() { 0 } else { 2 + sizeof_len(self.f_repeated_packed_float.len() * 4) }
         + self.f_imported.as_ref().map_or(0, |m| 2 + sizeof_len((m).get_size()))
         + self.f_baz.as_ref().map_or(0, |m| 2 + sizeof_len((m).get_size()))
         + self.f_nested.as_ref().map_or(0, |m| 2 + sizeof_len((m).get_size()))
-        + self.f_nested_enum.as_ref().map_or(0, |m| 2 + sizeof_varint(*(m) as u64))
-        + self.f_map.iter().map(|(k, v)| 2 + sizeof_len(2 + sizeof_len((k).len()) + sizeof_varint(*(v) as u64))).sum::<usize>()
+        + self.f_nested_enum.as_ref().map_or(0, |m| 2 + sizeof_varint(*(m) as u32 as u64))
+        + self.f_map.iter().map(|(k, v)| 2 + sizeof_len(2 + sizeof_len((k).len()) + sizeof_varint(*(v) as u32 as u64))).sum::<usize>()
         + match self.test_oneof {
-            mod_FooMessage::OneOftest_oneof::f1(ref m) => 2 + sizeof_varint(*(m) as u64),
+            mod_FooMessage::OneOftest_oneof::f1(ref m) => 2 + sizeof_varint(*(m) as u32 as u64),
             mod_FooMessage::OneOftest_oneof::f2(ref m) => 2 + sizeof_varint(*(m) as u64),
             mod_FooMessage::OneOftest_oneof::f3(ref m) => 2 + sizeof_len((m).len()),
             mod_FooMessage::OneOftest_oneof::None => 0,
@@ -215,13 +215,13 @@ impl<'a> MessageWrite for FooMessage<'a> {
         if let Some(ref s) = self.f_self_message { w.write_with_tag(138, |w| w.write_message(&**s))?; }
         if let Some(ref s) = self.f_bar_message { w.write_with_tag(146, |w| w.write_message(s))?; }
         for s in &self.f_repeated_int32 { w.write_with_tag(152, |w| w.write_int32(*s))?; }
-        w.write_packed_with_tag(162, &self.f_repeated_packed_int32, |w, m| w.write_int32(*m), &|m| sizeof_varint(*(m) as u64))?;
+        w.write_packed_with_tag(162, &self.f_repeated_packed_int32, |w, m| w.write_int32(*m), &|m| sizeof_varint(*(m) as u32 as u64))?;
         w.write_packed_fixed_with_tag(170, &self.f_repeated_packed_float)?;
         if let Some(ref s) = self.f_imported { w.write_with_tag(178, |w| w.write_message(s))?; }
         if let Some(ref s) = self.f_baz { w.write_with_tag(186, |w| w.write_message(s))?; }
         if let Some(ref s) = self.f_nested { w.write_with_tag(194, |w| w.write_message(s))?; }
         if let Some(ref s) = self.f_nested_enum { w.write_with_tag(200, |w| w.write_enum(*s as i32))?; }
-        for (k, v) in self.f_map.iter() { w.write_with_tag(210, |w| w.write_map(2 + sizeof_len((k).len()) + sizeof_varint(*(v) as u64), 10, |w| w.write_string(&**k), 16, |w| w.write_int32(*v)))?; }
+        for (k, v) in self.f_map.iter() { w.write_with_tag(210, |w| w.write_map(2 + sizeof_len((k).len()) + sizeof_varint(*(v) as u32 as u64), 10, |w| w.write_string(&**k), 16, |w| w.write_int32(*v)))?; }
         match self.test_oneof {            mod_FooMessage::OneOftest_oneof::f1(ref m) => { w.write_with_tag(216, |w| w.write_int32(*m))? },
             mod_FooMessage::OneOftest_oneof::f2(ref m) => { w.write_with_tag(224, |w| w.write_bool(*m))? },
             mod_FooMessage::OneOftest_oneof::f3(ref m) => { w.write_with_tag(234, |w| w.write_string(&**m))? },
@@ -342,7 +342,7 @@ impl<'a> MessageRead<'a> for NestedMessage {
 impl MessageWrite for NestedMessage {
     fn get_size(&self) -> usize {
         0
-        + 1 + sizeof_varint(*(&self.f_nested) as u64)
+        + 1 + sizeof_varint(*(&self.f_nested) as u32 as u64)
     }
 
     fn write_message<W: WriterBackend>(&self, w: &mut Writer<W>) -> Result<()> {

--- a/quick-protobuf/examples/pb_rs_nostd/protos/no_std.rs
+++ b/quick-protobuf/examples/pb_rs_nostd/protos/no_std.rs
@@ -71,8 +71,8 @@ impl<'a> MessageRead<'a> for EmbeddedMessage {
 impl MessageWrite for EmbeddedMessage {
     fn get_size(&self) -> usize {
         0
-        + if self.val == 0i32 { 0 } else { 1 + sizeof_varint(*(&self.val) as u64) }
-        + if self.e == protos::no_std::MyEnum::Val0 { 0 } else { 1 + sizeof_varint(*(&self.e) as u64) }
+        + if self.val == 0i32 { 0 } else { 1 + sizeof_varint(*(&self.val) as u32 as u64) }
+        + if self.e == protos::no_std::MyEnum::Val0 { 0 } else { 1 + sizeof_varint(*(&self.e) as u32 as u64) }
     }
 
     fn write_message<W: WriterBackend>(&self, w: &mut Writer<W>) -> Result<()> {

--- a/quick-protobuf/examples/pb_rs_v3/data_types.rs
+++ b/quick-protobuf/examples/pb_rs_v3/data_types.rs
@@ -70,7 +70,7 @@ impl<'a> MessageRead<'a> for BarMessage {
 impl MessageWrite for BarMessage {
     fn get_size(&self) -> usize {
         0
-        + if self.b_int32 == 0i32 { 0 } else { 1 + sizeof_varint(*(&self.b_int32) as u64) }
+        + if self.b_int32 == 0i32 { 0 } else { 1 + sizeof_varint(*(&self.b_int32) as u32 as u64) }
     }
 
     fn write_message<W: WriterBackend>(&self, w: &mut Writer<W>) -> Result<()> {
@@ -166,14 +166,14 @@ impl<'a> MessageRead<'a> for FooMessage<'a> {
 impl<'a> MessageWrite for FooMessage<'a> {
     fn get_size(&self) -> usize {
         0
-        + if self.f_int32 == 0i32 { 0 } else { 1 + sizeof_varint(*(&self.f_int32) as u64) }
+        + if self.f_int32 == 0i32 { 0 } else { 1 + sizeof_varint(*(&self.f_int32) as u32 as u64) }
         + if self.f_int64 == 0i64 { 0 } else { 1 + sizeof_varint(*(&self.f_int64) as u64) }
         + if self.f_uint32 == 0u32 { 0 } else { 1 + sizeof_varint(*(&self.f_uint32) as u64) }
         + if self.f_uint64 == 0u64 { 0 } else { 1 + sizeof_varint(*(&self.f_uint64) as u64) }
         + if self.f_sint32 == 0i32 { 0 } else { 1 + sizeof_sint32(*(&self.f_sint32)) }
         + if self.f_sint64 == 4i64 { 0 } else { 1 + sizeof_sint64(*(&self.f_sint64)) }
         + if self.f_bool == true { 0 } else { 1 + sizeof_varint(*(&self.f_bool) as u64) }
-        + if self.f_FooEnum == data_types::FooEnum::FIRST_VALUE { 0 } else { 1 + sizeof_varint(*(&self.f_FooEnum) as u64) }
+        + if self.f_FooEnum == data_types::FooEnum::FIRST_VALUE { 0 } else { 1 + sizeof_varint(*(&self.f_FooEnum) as u32 as u64) }
         + if self.f_fixed64 == 0u64 { 0 } else { 1 + 8 }
         + if self.f_sfixed64 == 0i64 { 0 } else { 1 + 8 }
         + if self.f_fixed32 == 0u32 { 0 } else { 1 + 4 }
@@ -184,18 +184,18 @@ impl<'a> MessageWrite for FooMessage<'a> {
         + if self.f_string == "" { 0 } else { 2 + sizeof_len((&self.f_string).len()) }
         + self.f_self_message.as_ref().map_or(0, |m| 2 + sizeof_len((m).get_size()))
         + self.f_bar_message.as_ref().map_or(0, |m| 2 + sizeof_len((m).get_size()))
-        + if self.f_repeated_int32.is_empty() { 0 } else { 2 + sizeof_len(self.f_repeated_int32.iter().map(|s| sizeof_varint(*(s) as u64)).sum::<usize>()) }
-        + if self.f_repeated_packed_int32.is_empty() { 0 } else { 2 + sizeof_len(self.f_repeated_packed_int32.iter().map(|s| sizeof_varint(*(s) as u64)).sum::<usize>()) }
+        + if self.f_repeated_int32.is_empty() { 0 } else { 2 + sizeof_len(self.f_repeated_int32.iter().map(|s| sizeof_varint(*(s) as u32 as u64)).sum::<usize>()) }
+        + if self.f_repeated_packed_int32.is_empty() { 0 } else { 2 + sizeof_len(self.f_repeated_packed_int32.iter().map(|s| sizeof_varint(*(s) as u32 as u64)).sum::<usize>()) }
         + if self.f_repeated_packed_float.is_empty() { 0 } else { 2 + sizeof_len(self.f_repeated_packed_float.len() * 4) }
         + self.f_imported.as_ref().map_or(0, |m| 2 + sizeof_len((m).get_size()))
         + self.f_baz.as_ref().map_or(0, |m| 2 + sizeof_len((m).get_size()))
         + self.f_nested.as_ref().map_or(0, |m| 2 + sizeof_len((m).get_size()))
-        + if self.f_nested_enum == data_types::mod_BazMessage::mod_Nested::NestedEnum::Foo { 0 } else { 2 + sizeof_varint(*(&self.f_nested_enum) as u64) }
-        + self.f_map.iter().map(|(k, v)| 2 + sizeof_len(2 + sizeof_len((k).len()) + sizeof_varint(*(v) as u64))).sum::<usize>()
+        + if self.f_nested_enum == data_types::mod_BazMessage::mod_Nested::NestedEnum::Foo { 0 } else { 2 + sizeof_varint(*(&self.f_nested_enum) as u32 as u64) }
+        + self.f_map.iter().map(|(k, v)| 2 + sizeof_len(2 + sizeof_len((k).len()) + sizeof_varint(*(v) as u32 as u64))).sum::<usize>()
         + self.f_repeated_string.iter().map(|s| 2 + sizeof_len((s).len())).sum::<usize>()
         + self.f_repeated_baz_message.iter().map(|s| 2 + sizeof_len((s).get_size())).sum::<usize>()
         + match self.test_oneof {
-            mod_FooMessage::OneOftest_oneof::f1(ref m) => 2 + sizeof_varint(*(m) as u64),
+            mod_FooMessage::OneOftest_oneof::f1(ref m) => 2 + sizeof_varint(*(m) as u32 as u64),
             mod_FooMessage::OneOftest_oneof::f2(ref m) => 2 + sizeof_varint(*(m) as u64),
             mod_FooMessage::OneOftest_oneof::f3(ref m) => 2 + sizeof_len((m).len()),
             mod_FooMessage::OneOftest_oneof::None => 0,
@@ -220,14 +220,14 @@ impl<'a> MessageWrite for FooMessage<'a> {
         if self.f_string != "" { w.write_with_tag(130, |w| w.write_string(&**&self.f_string))?; }
         if let Some(ref s) = self.f_self_message { w.write_with_tag(138, |w| w.write_message(&**s))?; }
         if let Some(ref s) = self.f_bar_message { w.write_with_tag(146, |w| w.write_message(s))?; }
-        w.write_packed_with_tag(154, &self.f_repeated_int32, |w, m| w.write_int32(*m), &|m| sizeof_varint(*(m) as u64))?;
-        w.write_packed_with_tag(162, &self.f_repeated_packed_int32, |w, m| w.write_int32(*m), &|m| sizeof_varint(*(m) as u64))?;
+        w.write_packed_with_tag(154, &self.f_repeated_int32, |w, m| w.write_int32(*m), &|m| sizeof_varint(*(m) as u32 as u64))?;
+        w.write_packed_with_tag(162, &self.f_repeated_packed_int32, |w, m| w.write_int32(*m), &|m| sizeof_varint(*(m) as u32 as u64))?;
         w.write_packed_fixed_with_tag(170, &self.f_repeated_packed_float)?;
         if let Some(ref s) = self.f_imported { w.write_with_tag(178, |w| w.write_message(s))?; }
         if let Some(ref s) = self.f_baz { w.write_with_tag(186, |w| w.write_message(s))?; }
         if let Some(ref s) = self.f_nested { w.write_with_tag(194, |w| w.write_message(s))?; }
         if self.f_nested_enum != data_types::mod_BazMessage::mod_Nested::NestedEnum::Foo { w.write_with_tag(200, |w| w.write_enum(*&self.f_nested_enum as i32))?; }
-        for (k, v) in self.f_map.iter() { w.write_with_tag(210, |w| w.write_map(2 + sizeof_len((k).len()) + sizeof_varint(*(v) as u64), 10, |w| w.write_string(&**k), 16, |w| w.write_int32(*v)))?; }
+        for (k, v) in self.f_map.iter() { w.write_with_tag(210, |w| w.write_map(2 + sizeof_len((k).len()) + sizeof_varint(*(v) as u32 as u64), 10, |w| w.write_string(&**k), 16, |w| w.write_int32(*v)))?; }
         for s in &self.f_repeated_string { w.write_with_tag(242, |w| w.write_string(&**s))?; }
         for s in &self.f_repeated_baz_message { w.write_with_tag(250, |w| w.write_message(s))?; }
         match self.test_oneof {            mod_FooMessage::OneOftest_oneof::f1(ref m) => { w.write_with_tag(216, |w| w.write_int32(*m))? },
@@ -358,7 +358,7 @@ impl<'a> MessageRead<'a> for NestedMessage {
 impl MessageWrite for NestedMessage {
     fn get_size(&self) -> usize {
         0
-        + if self.f_nested == 0i32 { 0 } else { 1 + sizeof_varint(*(&self.f_nested) as u64) }
+        + if self.f_nested == 0i32 { 0 } else { 1 + sizeof_varint(*(&self.f_nested) as u32 as u64) }
     }
 
     fn write_message<W: WriterBackend>(&self, w: &mut Writer<W>) -> Result<()> {

--- a/quick-protobuf/src/writer.rs
+++ b/quick-protobuf/src/writer.rs
@@ -84,7 +84,7 @@ impl<W: WriterBackend> Writer<W> {
     /// Writes a `int32` which is internally coded as a `varint`
     #[cfg_attr(std, inline(always))]
     pub fn write_int32(&mut self, v: i32) -> Result<()> {
-        self.write_varint(v as u64)
+        self.write_varint(v as u32 as u64)
     }
 
     /// Writes a `int64` which is internally coded as a `varint`


### PR DESCRIPTION
`-...i32 as u64` results in sign-extending all the way to 64 bits, which I assume is incorrect according to the protobuf spec. Changing it to `as u32 as u64` should sign-extend to 32 bits and then zero-extend from there to 64 bits, resulting in what I assume is the correct behavior.

Demo: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=dc9845eb3a846f6658029234ab801478

```rust
fn main() {
    println!("{}", (-1i32) as u64);
    println!("{}", (-1i32) as u32 as u64);
}
```

```
18446744073709551615
4294967295
```