### PR TITLE
bump version numbers, update changelog, prep for release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,19 @@
   - test: Adding missing tests
   - chore: Changes to the build process or auxiliary tools/libraries/documentation
 
+## pb-rs 0.10.0
+- fix: fix nested items and package name resolution
+- fix: parser now parses comments successfully
+- fix: parser now rejects missing names and types
+- fix: parser now enforces more variable naming/qualification rules
+- fix: deprecated fields no longer propagate their lifetimes to containing message
+- fix: deprecated fields are now ignored in enums (previously would throw error)
+- fix: fix unsoundness in Owned variant (breaking change)
+
+## quick-protobuf 0.8.1
+- fix: added overflow checking in `read_unknown()`
+- fix: fix buffer size check in `serialize_into_slice()`
+
 ## pb-rs 0.9.1
 - feat: allow hexadecimal tag numbers
 - fix: Fix empty bytes field checking when `--dont_use_cow` flag is used.

--- a/pb-rs/Cargo.toml
+++ b/pb-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pb-rs"
-version = "0.9.1"
+version = "0.10.0"
 description = "A converter from proto files into quick-protobuf compatible Rust module"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 keywords = ["protobuf", "parser", "quick-protobuf"]

--- a/quick-protobuf/Cargo.toml
+++ b/quick-protobuf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quick-protobuf"
 description = "A pure Rust protobuf (de)serializer. Quick."
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 keywords = ["protobuf", "parser"]
 license = "MIT"


### PR DESCRIPTION
# Preparing for release
- `pb-rs` goes from `0.9.1` to `0.10.0` due to breaking change in #153 
- `quick-protobuf` goes from `0.8.0` to `0.8.1`, no breaking changes as far as I can tell
- no changes to `perftest`