### PR TITLE
Fix UB in read_packed_fixed()

### DIFF
--- a/pb-rs/src/types.rs
+++ b/pb-rs/src/types.rs
@@ -502,7 +502,7 @@ impl Field {
             Frequency::Repeated
                 if self.packed() && self.typ.is_fixed_size() && !config.dont_use_cow =>
             {
-                writeln!(w, "Cow<'a, [{}]>,", rust_type)?;
+                writeln!(w, "PackedFixed<'a, {}>,", rust_type)?;
             }
             Frequency::Repeated => writeln!(w, "Vec<{}>,", rust_type)?,
             Frequency::Required | Frequency::Optional => writeln!(w, "{},", rust_type)?,
@@ -546,10 +546,10 @@ impl Field {
                 writeln!(w, "msg.{} = Some({}),", name, val_cow)?
             }
             Frequency::Required | Frequency::Optional => {
-                writeln!(w, "msg.{} = {},", name, val_cow)?
+                writeln!(w, "msg.{} = {},", name, val_cow)?;
             }
             Frequency::Repeated if self.packed() && self.typ.is_fixed_size() => {
-                writeln!(w, "msg.{} = r.read_packed_fixed(bytes)?.into(),", name)?;
+                writeln!(w, "msg.{} = r.read_packed_fixed(bytes)?,", name)?;
             }
             Frequency::Repeated if self.packed() => {
                 writeln!(
@@ -2344,7 +2344,7 @@ impl FileDescriptor {
 
         writeln!(
             w,
-            "use quick_protobuf::{{MessageInfo, MessageRead, MessageWrite, BytesReader, Writer, WriterBackend, Result}};"
+            "use quick_protobuf::{{MessageInfo, MessageRead, MessageWrite, BytesReader, Writer, WriterBackend, Result, PackedFixed, PackedFixedIntoIter, PackedFixedRefIter}};"
         )?;
 
         if self.owned {

--- a/quick-protobuf/examples/pb_rs/a/b.rs
+++ b/quick-protobuf/examples/pb_rs/a/b.rs
@@ -9,7 +9,7 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 
-use quick_protobuf::{MessageInfo, MessageRead, MessageWrite, BytesReader, Writer, WriterBackend, Result};
+use quick_protobuf::{MessageInfo, MessageRead, MessageWrite, BytesReader, Writer, WriterBackend, Result, PackedFixed, PackedFixedIntoIter, PackedFixedRefIter};
 use quick_protobuf::sizeofs::*;
 use super::super::*;
 

--- a/quick-protobuf/examples/pb_rs/data_types.rs
+++ b/quick-protobuf/examples/pb_rs/data_types.rs
@@ -12,7 +12,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 type KVMap<K, V> = HashMap<K, V>;
-use quick_protobuf::{MessageInfo, MessageRead, MessageWrite, BytesReader, Writer, WriterBackend, Result};
+use quick_protobuf::{MessageInfo, MessageRead, MessageWrite, BytesReader, Writer, WriterBackend, Result, PackedFixed, PackedFixedIntoIter, PackedFixedRefIter};
 use quick_protobuf::sizeofs::*;
 use super::*;
 
@@ -103,7 +103,7 @@ pub struct FooMessage<'a> {
     pub f_bar_message: Option<BarMessage>,
     pub f_repeated_int32: Vec<i32>,
     pub f_repeated_packed_int32: Vec<i32>,
-    pub f_repeated_packed_float: Cow<'a, [f32]>,
+    pub f_repeated_packed_float: PackedFixed<'a, f32>,
     pub f_imported: Option<a::b::ImportedMessage>,
     pub f_baz: Option<BazMessage>,
     pub f_nested: Option<mod_BazMessage::Nested>,
@@ -141,7 +141,7 @@ impl<'a> MessageRead<'a> for FooMessage<'a> {
                 Ok(146) => msg.f_bar_message = Some(r.read_message::<BarMessage>(bytes)?),
                 Ok(152) => msg.f_repeated_int32.push(r.read_int32(bytes)?),
                 Ok(162) => msg.f_repeated_packed_int32 = r.read_packed(bytes, |r, bytes| Ok(r.read_int32(bytes)?))?,
-                Ok(170) => msg.f_repeated_packed_float = r.read_packed_fixed(bytes)?.into(),
+                Ok(170) => msg.f_repeated_packed_float = r.read_packed_fixed(bytes)?,
                 Ok(178) => msg.f_imported = Some(r.read_message::<a::b::ImportedMessage>(bytes)?),
                 Ok(186) => msg.f_baz = Some(r.read_message::<BazMessage>(bytes)?),
                 Ok(194) => msg.f_nested = Some(r.read_message::<mod_BazMessage::Nested>(bytes)?),

--- a/quick-protobuf/examples/pb_rs_nostd/protos/no_std.rs
+++ b/quick-protobuf/examples/pb_rs_nostd/protos/no_std.rs
@@ -11,7 +11,7 @@
 
 use alloc::vec::Vec;
 use alloc::borrow::Cow;
-use quick_protobuf::{MessageInfo, MessageRead, MessageWrite, BytesReader, Writer, WriterBackend, Result};
+use quick_protobuf::{MessageInfo, MessageRead, MessageWrite, BytesReader, Writer, WriterBackend, Result, PackedFixed, PackedFixedIntoIter, PackedFixedRefIter};
 use quick_protobuf::sizeofs::*;
 use super::super::*;
 
@@ -87,7 +87,7 @@ impl MessageWrite for EmbeddedMessage {
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct NoStdMessage<'a> {
     pub num: u32,
-    pub nums: Cow<'a, [u32]>,
+    pub nums: PackedFixed<'a, u32>,
     pub message: Option<protos::no_std::EmbeddedMessage>,
     pub messages: Vec<protos::no_std::EmbeddedMessage>,
 }
@@ -98,7 +98,7 @@ impl<'a> MessageRead<'a> for NoStdMessage<'a> {
         while !r.is_eof() {
             match r.next_tag(bytes) {
                 Ok(13) => msg.num = r.read_fixed32(bytes)?,
-                Ok(18) => msg.nums = r.read_packed_fixed(bytes)?.into(),
+                Ok(18) => msg.nums = r.read_packed_fixed(bytes)?,
                 Ok(26) => msg.message = Some(r.read_message::<protos::no_std::EmbeddedMessage>(bytes)?),
                 Ok(34) => msg.messages.push(r.read_message::<protos::no_std::EmbeddedMessage>(bytes)?),
                 Ok(t) => { r.read_unknown(bytes, t)?; }

--- a/quick-protobuf/examples/pb_rs_v3/a/b.rs
+++ b/quick-protobuf/examples/pb_rs_v3/a/b.rs
@@ -9,7 +9,7 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 
-use quick_protobuf::{MessageInfo, MessageRead, MessageWrite, BytesReader, Writer, WriterBackend, Result};
+use quick_protobuf::{MessageInfo, MessageRead, MessageWrite, BytesReader, Writer, WriterBackend, Result, PackedFixed, PackedFixedIntoIter, PackedFixedRefIter};
 use quick_protobuf::sizeofs::*;
 use super::super::*;
 

--- a/quick-protobuf/examples/pb_rs_v3/data_types.rs
+++ b/quick-protobuf/examples/pb_rs_v3/data_types.rs
@@ -12,7 +12,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 type KVMap<K, V> = HashMap<K, V>;
-use quick_protobuf::{MessageInfo, MessageRead, MessageWrite, BytesReader, Writer, WriterBackend, Result};
+use quick_protobuf::{MessageInfo, MessageRead, MessageWrite, BytesReader, Writer, WriterBackend, Result, PackedFixed, PackedFixedIntoIter, PackedFixedRefIter};
 use quick_protobuf::sizeofs::*;
 use super::*;
 
@@ -103,7 +103,7 @@ pub struct FooMessage<'a> {
     pub f_bar_message: Option<BarMessage>,
     pub f_repeated_int32: Vec<i32>,
     pub f_repeated_packed_int32: Vec<i32>,
-    pub f_repeated_packed_float: Cow<'a, [f32]>,
+    pub f_repeated_packed_float: PackedFixed<'a, f32>,
     pub f_imported: Option<a::b::ImportedMessage>,
     pub f_baz: Option<BazMessage<'a>>,
     pub f_nested: Option<mod_BazMessage::Nested>,
@@ -143,7 +143,7 @@ impl<'a> MessageRead<'a> for FooMessage<'a> {
                 Ok(146) => msg.f_bar_message = Some(r.read_message::<BarMessage>(bytes)?),
                 Ok(154) => msg.f_repeated_int32 = r.read_packed(bytes, |r, bytes| Ok(r.read_int32(bytes)?))?,
                 Ok(162) => msg.f_repeated_packed_int32 = r.read_packed(bytes, |r, bytes| Ok(r.read_int32(bytes)?))?,
-                Ok(170) => msg.f_repeated_packed_float = r.read_packed_fixed(bytes)?.into(),
+                Ok(170) => msg.f_repeated_packed_float = r.read_packed_fixed(bytes)?,
                 Ok(178) => msg.f_imported = Some(r.read_message::<a::b::ImportedMessage>(bytes)?),
                 Ok(186) => msg.f_baz = Some(r.read_message::<BazMessage>(bytes)?),
                 Ok(194) => msg.f_nested = Some(r.read_message::<mod_BazMessage::Nested>(bytes)?),

--- a/quick-protobuf/src/lib.rs
+++ b/quick-protobuf/src/lib.rs
@@ -14,7 +14,9 @@ pub mod writer;
 
 pub use crate::errors::{Error, Result};
 pub use crate::message::{MessageInfo, MessageRead, MessageWrite};
-pub use crate::reader::{deserialize_from_slice, BytesReader};
+pub use crate::reader::{
+    deserialize_from_slice, BytesReader, PackedFixed, PackedFixedIntoIter, PackedFixedRefIter,
+};
 pub use crate::writer::{serialize_into_slice, BytesWriter, Writer, WriterBackend};
 
 #[cfg(feature = "std")]

--- a/quick-protobuf/src/writer.rs
+++ b/quick-protobuf/src/writer.rs
@@ -1,5 +1,6 @@
 //! A module to manage protobuf serialization
 
+use crate::PackedFixed;
 use crate::errors::{Error, Result};
 use crate::message::MessageWrite;
 
@@ -201,9 +202,15 @@ impl<W: WriterBackend> Writer<W> {
     /// As the length is fixed (and the same as rust internal representation, we can directly dump
     /// all data at once
     #[cfg_attr(std, inline)]
-    pub fn write_packed_fixed<M>(&mut self, v: &[M]) -> Result<()> {
-        let len = v.len() * ::core::mem::size_of::<M>();
-        let bytes = unsafe { ::core::slice::from_raw_parts(v.as_ptr() as *const u8, len) };
+    pub fn write_packed_fixed<M: Copy + PartialEq>(&mut self, pf: &PackedFixed<M>) -> Result<()> {
+        let bytes = match pf {
+            PackedFixed::NoDataYet => unreachable!(),
+            PackedFixed::Borrowed(bytes) => bytes,
+            PackedFixed::Owned(contents) => {
+                let len = ::core::mem::size_of::<M>() * contents.len();
+                unsafe { ::core::slice::from_raw_parts(contents.as_ptr() as *const u8, len) }
+            },
+        };
         self.write_bytes(bytes)
     }
 
@@ -255,33 +262,36 @@ impl<W: WriterBackend> Writer<W> {
     /// Writes tag then repeated field
     ///
     /// If array is empty, then do nothing (do not even write the tag)
-    pub fn write_packed_fixed_with_tag<M>(&mut self, tag: u32, v: &[M]) -> Result<()> {
-        if v.is_empty() {
+    pub fn write_packed_fixed_with_tag<M: Copy + PartialEq>(&mut self, tag: u32, pf: &PackedFixed<M>) -> Result<()> {
+        if pf.is_empty() {
             return Ok(());
         }
 
         self.write_tag(tag)?;
-        let len = ::core::mem::size_of::<M>() * v.len();
-        let bytes = unsafe { ::core::slice::from_raw_parts(v.as_ptr() as *const u8, len) };
-        self.write_bytes(bytes)
+        self.write_packed_fixed(pf)
     }
 
     /// Writes tag then repeated field with fixed length item size
     ///
     /// If array is empty, then do nothing (do not even write the tag)
-    pub fn write_packed_fixed_size_with_tag<M>(
+    pub fn write_packed_fixed_size_with_tag<M: Copy + PartialEq>(
         &mut self,
         tag: u32,
-        v: &[M],
+        pf: &PackedFixed<M>,
         item_size: usize,
     ) -> Result<()> {
-        if v.is_empty() {
+        if pf.is_empty() {
             return Ok(());
         }
+
         self.write_tag(tag)?;
-        let len = v.len() * item_size;
-        let bytes =
-            unsafe { ::core::slice::from_raw_parts(v as *const [M] as *const M as *const u8, len) };
+
+        let len = ::core::mem::size_of::<M>() * item_size;
+        let bytes = match pf {
+            PackedFixed::NoDataYet => unreachable!(),
+            PackedFixed::Borrowed(bytes) => &bytes[0..len],
+            PackedFixed::Owned(contents) => unsafe { ::core::slice::from_raw_parts(contents.as_ptr() as *const u8, len) },
+        };
         self.write_bytes(bytes)
     }
 

--- a/quick-protobuf/tests/rust_protobuf/test_utils.rs
+++ b/quick-protobuf/tests/rust_protobuf/test_utils.rs
@@ -41,6 +41,23 @@ macro_rules! test_serialize_deserialize_length_delimited {
     };
 }
 
+macro_rules! test_serialize_deserialize_packed_fixed {
+    ($msg:expr, $name:ident, $parsed:ident, $modification:block) => {
+        let mut serialized = Vec::new();
+        {
+            let mut writer = Writer::new(&mut serialized);
+            writer.write_message($msg).unwrap();
+        }
+        let mut reader = BytesReader::from_bytes(&serialized);
+        let mut $parsed: $name = reader.read_message(&serialized).unwrap();
+
+        $modification
+
+        println!("{:#?}, {:#?}", $msg, $parsed);
+        assert!($msg.eq(&$parsed));
+    };
+}
+
 macro_rules! test_serialize_deserialize {
     ($hex:expr, $msg:expr, $name:ident) => {
         let expected_bytes = decode_hex($hex);

--- a/quick-protobuf/tests/rust_protobuf/v2/test_basic.rs
+++ b/quick-protobuf/tests/rust_protobuf/v2/test_basic.rs
@@ -142,7 +142,14 @@ fn test_types_repeated_packed() {
     message.string_field = vec!["thirty two".into(), "thirty three".into()];
     message.bytes_field = vec![vec![33u8, 34].into(), vec![35u8].into()];
     message.enum_field = vec![TestEnumDescriptor::BLUE, TestEnumDescriptor::GREEN];
-    test_serialize_deserialize_length_delimited!(&message, TestTypesRepeatedPacked);
+    test_serialize_deserialize_packed_fixed!(&message, TestTypesRepeatedPacked, parsed, {
+        parsed.double_field.own();
+        parsed.float_field.own();
+        parsed.fixed32_field.own();
+        parsed.fixed64_field.own();
+        parsed.sfixed32_field.own();
+        parsed.sfixed64_field.own();
+    });
 }
 
 // #[test]

--- a/quick-protobuf/tests/rust_protobuf/v3/test_basic.rs
+++ b/quick-protobuf/tests/rust_protobuf/v3/test_basic.rs
@@ -143,7 +143,14 @@ fn test_types_repeated_packed() {
     message.string_field = vec!["thirty two".into(), "thirty three".into()];
     message.bytes_field = vec![vec![33u8, 34].into(), vec![35u8].into()];
     message.enum_field = vec![TestEnumDescriptor::BLUE, TestEnumDescriptor::GREEN];
-    test_serialize_deserialize_length_delimited!(&message, TestTypesRepeatedPacked);
+    test_serialize_deserialize_packed_fixed!(&message, TestTypesRepeatedPacked, parsed, {
+        parsed.double_field.own();
+        parsed.float_field.own();
+        parsed.fixed32_field.own();
+        parsed.fixed64_field.own();
+        parsed.sfixed32_field.own();
+        parsed.sfixed64_field.own();
+    });
 }
 
 // #[test]

--- a/quick-protobuf/tests/write_read.rs
+++ b/quick-protobuf/tests/write_read.rs
@@ -1,6 +1,6 @@
 extern crate quick_protobuf;
 
-use quick_protobuf::sizeofs::*;
+use quick_protobuf::{sizeofs::*, PackedFixed};
 use quick_protobuf::{deserialize_from_slice, serialize_into_slice, serialize_into_vec};
 use quick_protobuf::{
     BytesReader, MessageRead, MessageWrite, Reader, Result, Writer, WriterBackend,
@@ -305,14 +305,15 @@ fn wr_packed_uint32() {
 
 #[test]
 fn wr_packed_float() {
-    let v = vec![43, 54, 64, 234, 6123, 643];
+    let pf: PackedFixed<i32> = vec![43, 54, 64, 234, 6123, 643].into();
     let mut buf = Vec::new();
     {
         let mut w = Writer::new(&mut buf);
-        w.write_packed_fixed(&v).unwrap();
+        w.write_packed_fixed(&pf).unwrap();
     }
     let mut r = BytesReader::from_bytes(&buf);
-    assert_eq!(v, r.read_packed_fixed(&buf).unwrap());
+    let res: Vec<i32> = r.read_packed_fixed(&buf).unwrap().into_vec();
+    assert_eq!(pf.into_vec(), res);
 }
 
 #[test]


### PR DESCRIPTION
# Problem: UB in `read_packed_fixed()`

Closes #215 (Thanks @saethlin for finding this)

# Solution
Breaking fix: In packed fixed fields, replace `Cow<'a, T>` with a similar custom struct `PackedFixed<'a, T>`, which exposes alignment-safe reading methods.

Other fields will still use `Cow<'a, T>`.

## `PackedFixed`
Like `Cow`, `PackedFixed` is an enum. It has the following variants:
- `PackedFixed::Borrowed`: Contains a reference to a (possibly) unaligned byte slice, and reads or iterates on the fly using `read_unaligned()`. This is the heart of this enum's purpose.
- `PackedFixed::Owned`: Contains an owned vector of the target encoded type. This is mainly for users to create their own owned `PackedFixed` instances without having to create a vector and reference it separately.
- `PackedFixed::NoDataYet`: Default state for initialization.

### Optimization?
There is also the fact that `PackedFixed::Owned` will *always* contain an aligned vector while `PackedFixed::Borrowed` contains a reference to bytes that *might* be unaligned, and so every read must go through `read_unaligned()`.

> In fact, the original names for the variants were `PackedFixed::Aligned` and `PackedFixed::MaybeUnaligned` instead of `PackedFixed::Owned` and `PackedFixed::Borrowed`.

From my own testing attempts, I can't really tell whether there are speed/compiler optimizations when reading from `PackedFixed::Owned` instead of `PackedFixed::Borrowed`. There does appear to be some rather big slowdowns (about 3x) of reads from `PackedFixed::Borrowed` depending on where that code is placed (a rather arbitrary factor), but I can't tell if this is an artifact of my own testing or not. However, methods to convert `PackedFixed::Borrowed` to `PackedFixed::Owned` are provided.

### Iterators
> `T` refers to the data type that is encoded by the raw bytes.

There are two iterators provided:
- `PackedFixedIntoIter`: Regular iterator that will move `self`, and returns `T` at each iteration.
- `PackedFixedRefIter`: Exactly the same as `PackedFixedIntoIter` (returns `T` as well), but works on `&PackedFixed` and therefore does not move `self`. It does *not* return `&T` despite iterating over `&PackedFixed` (see section Returning Referencesbelow); this is why we do not follow the convention of naming it `PackedFixedIter`.

### Returning References
Because `read_unaligned()` does a bitwise copy and returns a new value, the `PackedFixed::Borrowed` variant cannot return references to the data that is encoded by its referenced bytes. It might technically be possible to implement methods that do for the enum in general (either panic when called on `PackedFixed::Borrowed` variant or convert to `PackedFixed::Owned` first) but I thought this would be rather confusing.