### PR TITLE
Serialize/Deserialize slices without length prefix with break-change

### DIFF
--- a/quick-protobuf/src/reader.rs
+++ b/quick-protobuf/src/reader.rs
@@ -480,8 +480,9 @@ impl BytesReader {
     pub fn read_message<'a, M>(&mut self, bytes: &'a [u8]) -> Result<M>
     where
         M: MessageRead<'a>,
-    {
-        self.read_len_varint(bytes, M::from_reader)
+    {        
+        let len = bytes.len();
+        self.read_len(bytes, M::from_reader, len)
     }
 
     /// Reads a nested message

--- a/quick-protobuf/src/writer.rs
+++ b/quick-protobuf/src/writer.rs
@@ -217,8 +217,6 @@ impl<W: WriterBackend> Writer<W> {
     /// Writes a message which implements `MessageWrite`
     #[cfg_attr(std, inline)]
     pub fn write_message<M: MessageWrite>(&mut self, m: &M) -> Result<()> {
-        let len = m.get_size();
-        self.write_varint(len as u64)?;
         m.write_message(self)
     }
 
@@ -331,7 +329,7 @@ pub fn serialize_into_vec<M: MessageWrite>(message: &M) -> Result<Vec<u8>> {
 /// Serialize a `MessageWrite` into a byte slice
 pub fn serialize_into_slice<M: MessageWrite>(message: &M, out: &mut [u8]) -> Result<()> {
     let len = message.get_size();
-    if out.len() < crate::sizeofs::sizeof_len(len) {
+    if out.len() < len {
         return Err(Error::OutputBufferTooSmall);
     }
     {


### PR DESCRIPTION
Following: 
- issue: https://github.com/tafia/quick-protobuf/issues/202
- pr: https://github.com/tafia/quick-protobuf/pull/208

 - [x] Message writer without prefixing a length
 - [x] Slice serializer without prefixing a length
 - [x] Reading messages that aren't prefixed with a length
 - [ ] pass test for all the above implementations