### PR TITLE
perftest: missing field in `Config`

### DIFF
--- a/perftest/build.rs
+++ b/perftest/build.rs
@@ -63,6 +63,7 @@ fn main() {
         nostd: false,
         gen_info: false,
         add_deprecated_fields: false,
+        generate_getters: true,
     };
     FileDescriptor::write_proto(&config).unwrap();
 


### PR DESCRIPTION
Fixes compile error due to missing field (`generate_getters`, introduced in #247).