### PR TITLE
workspace: hide clippy warnings

### DIFF
--- a/pb-rs/src/lib.rs
+++ b/pb-rs/src/lib.rs
@@ -17,34 +17,34 @@ use types::Config;
 /// use std::path::{Path, PathBuf};
 /// use walkdir::WalkDir;
 ///
-/// fn main() {
-///     let out_dir = std::env::var("OUT_DIR").unwrap();
-///     let out_dir = Path::new(&out_dir).join("protos");
+/// # fn main() {
+/// let out_dir = std::env::var("OUT_DIR").unwrap();
+/// let out_dir = Path::new(&out_dir).join("protos");
 ///
-///     let in_dir = PathBuf::from(::std::env::var("CARGO_MANIFEST_DIR").unwrap()).join("protos");
-///     // Re-run this build.rs if the protos dir changes (i.e. a new file is added)
-///     println!("cargo:rerun-if-changed={}", in_dir.to_str().unwrap());
+/// let in_dir = PathBuf::from(::std::env::var("CARGO_MANIFEST_DIR").unwrap()).join("protos");
+/// // Re-run this build.rs if the protos dir changes (i.e. a new file is added)
+/// println!("cargo:rerun-if-changed={}", in_dir.to_str().unwrap());
 ///
-///     // Find all *.proto files in the `in_dir` and add them to the list of files
-///     let mut protos = Vec::new();
-///     let proto_ext = Some(Path::new("proto").as_os_str());
-///     for entry in WalkDir::new(&in_dir) {
-///         let path = entry.unwrap().into_path();
-///         if path.extension() == proto_ext {
-///             // Re-run this build.rs if any of the files in the protos dir change
-///             println!("cargo:rerun-if-changed={}", path.to_str().unwrap());
-///             protos.push(path);
-///         }
+/// // Find all *.proto files in the `in_dir` and add them to the list of files
+/// let mut protos = Vec::new();
+/// let proto_ext = Some(Path::new("proto").as_os_str());
+/// for entry in WalkDir::new(&in_dir) {
+///     let path = entry.unwrap().into_path();
+///     if path.extension() == proto_ext {
+///         // Re-run this build.rs if any of the files in the protos dir change
+///         println!("cargo:rerun-if-changed={}", path.to_str().unwrap());
+///         protos.push(path);
 ///     }
-///
-///     // Delete all old generated files before re-generating new ones
-///     if out_dir.exists() {
-///         std::fs::remove_dir_all(&out_dir).unwrap();
-///     }
-///     std::fs::DirBuilder::new().create(&out_dir).unwrap();
-///     let config_builder = ConfigBuilder::new(&protos, None, Some(&out_dir), &[in_dir]).unwrap();
-///     FileDescriptor::run(&config_builder.build()).unwrap()
 /// }
+///
+/// // Delete all old generated files before re-generating new ones
+/// if out_dir.exists() {
+///     std::fs::remove_dir_all(&out_dir).unwrap();
+/// }
+/// std::fs::DirBuilder::new().create(&out_dir).unwrap();
+/// let config_builder = ConfigBuilder::new(&protos, None, Some(&out_dir), &[in_dir]).unwrap();
+/// FileDescriptor::run(&config_builder.build()).unwrap()
+/// # }
 /// ```
 #[derive(Debug, Default)]
 pub struct ConfigBuilder {

--- a/pb-rs/src/parser.rs
+++ b/pb-rs/src/parser.rs
@@ -27,6 +27,7 @@ enum ParsingStageFrequencyToken {
 }
 
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 enum MessageEvent {
     Message(Message),
     Enumerator(Enumerator),
@@ -695,7 +696,7 @@ mod test {
 
     #[test]
     fn empty_message() {
-        test_syntaxes(move |syntax: Syntax| -> Result<(), &str> {
+        test_syntaxes(move |syntax| -> Result<(), &str> {
             let msg = r#"message Vec { }"#;
             let mess = assert_complete(message(syntax)(msg))?;
             result_assert_eq("Vec", &mess.name, None)?;
@@ -707,7 +708,7 @@ mod test {
 
     #[test]
     fn test_enum() {
-        test_syntaxes(move |syntax: Syntax| -> Result<(), &str> {
+        test_syntaxes(move |_| -> Result<(), &str> {
             let msg = r#"enum PairingStatus {
                 DEALPAIRED        = 0;
                 INVENTORYORPHAN   = 1;
@@ -747,8 +748,8 @@ mod test {
             ::nom::IResult::Ok(_) => (),
             e => panic!("Expecting done {:?}", e),
         }
-        assert_desc(msg);
-        assert_desc(msg2);
+        assert_desc(msg).unwrap();
+        assert_desc(msg2).unwrap();
     }
 
     #[test]
@@ -1059,7 +1060,7 @@ mod test {
 
     #[test]
     fn enum_comments() {
-        test_syntaxes(move |syntax: Syntax| -> Result<(), &str> {
+        test_syntaxes(move |_| -> Result<(), &str> {
             let msg = r#"enum Turn {
                 UP = 0;
                 // for what?

--- a/pb-rs/src/scc.rs
+++ b/pb-rs/src/scc.rs
@@ -1,4 +1,4 @@
-use crate::types::{FileDescriptor, Frequency, MessageIndex};
+use crate::types::{FileDescriptor, MessageIndex};
 use std::cmp::min;
 use std::collections::HashMap;
 
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 ///
 /// Uses Tarjan's algorithm
 /// https://www.geeksforgeeks.org/tarjan-algorithm-find-strongly-connected-components/
+#[allow(clippy::too_many_arguments)]
 fn scc(
     vertices: &[MessageIndex],
     desc: &FileDescriptor,

--- a/pb-rs/src/types.rs
+++ b/pb-rs/src/types.rs
@@ -20,16 +20,11 @@ fn sizeof_varint(v: u32) -> usize {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum Syntax {
+    #[default]
     Proto2,
     Proto3,
-}
-
-impl Default for Syntax {
-    fn default() -> Syntax {
-        Syntax::Proto2
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1983,7 +1978,7 @@ impl Message {
             if let Some(var) = f.default.as_ref() {
                 if let FieldType::Enum(ref e) = f.typ {
                     let e = e.get_enum(desc);
-                    e.fields.iter().find(|&(ref name, _)| name == var)
+                    e.fields.iter().find(|(name, _)| name == var)
                     .ok_or_else(|| Error::InvalidDefaultEnum(format!(
                                 "Error in message {}\n\
                                 Enum field {:?} has a default value '{}' which is not valid for enum index {:?}",
@@ -2187,7 +2182,7 @@ impl Enumerator {
     fn write_definition<W: Write>(&self, w: &mut W) -> Result<()> {
         writeln!(w, "#[derive(Debug, PartialEq, Eq, Clone, Copy)]")?;
         writeln!(w, "pub enum {} {{", self.name)?;
-        for &(ref f, ref number) in &self.fields {
+        for (f, number) in &self.fields {
             writeln!(w, "    {} = {},", f, number)?;
         }
         writeln!(w, "}}")?;
@@ -2208,7 +2203,7 @@ impl Enumerator {
         writeln!(w, "impl From<i32> for {} {{", self.name)?;
         writeln!(w, "    fn from(i: i32) -> Self {{")?;
         writeln!(w, "        match i {{")?;
-        for &(ref f, ref number) in &self.fields {
+        for (f, ref number) in &self.fields {
             writeln!(w, "            {} => {}::{},", number, self.name, f)?;
         }
         writeln!(w, "            _ => Self::default(),")?;
@@ -2222,7 +2217,7 @@ impl Enumerator {
         writeln!(w, "impl<'a> From<&'a str> for {} {{", self.name)?;
         writeln!(w, "    fn from(s: &'a str) -> Self {{")?;
         writeln!(w, "        match s {{")?;
-        for &(ref f, _) in &self.fields {
+        for (f, _) in &self.fields {
             writeln!(w, "            {:?} => {}::{},", f, self.name, f)?;
         }
         writeln!(w, "            _ => Self::default(),")?;

--- a/perftest/build.rs
+++ b/perftest/build.rs
@@ -38,7 +38,7 @@ fn main() {
     // protobuf
     protobuf_codegen_pure::Codegen::new()
         .out_dir("src")
-        .inputs(&["src/perftest_data.proto"])
+        .inputs(["src/perftest_data.proto"])
         .include("src")
         .run()
         .expect("protoc");
@@ -71,6 +71,6 @@ fn main() {
     let old = ::std::env::var("OUT_DIR");
     env::set_var("OUT_DIR", ".");
     prost_build::compile_protos(&["src/perftest_data.proto"], &["src"]).unwrap();
-    let _ = old.map(|val| env::set_var("OUT_DIR", &val));
+    let _ = old.map(|val| env::set_var("OUT_DIR", val));
     fs::rename("perftest_data.rs", "src/perftest_data_prost.rs").unwrap();
 }

--- a/quick-protobuf/src/errors.rs
+++ b/quick-protobuf/src/errors.rs
@@ -32,9 +32,9 @@ pub enum Error {
 pub type Result<T> = ::core::result::Result<T, Error>;
 
 #[cfg(feature = "std")]
-impl Into<std::io::Error> for Error {
-    fn into(self) -> ::std::io::Error {
-        match self {
+impl From<Error> for std::io::Error {
+    fn from(val: Error) -> Self {
+        match val {
             Error::Io(x) => x,
             Error::Utf8(x) => std::io::Error::new(std::io::ErrorKind::InvalidData, x),
             x => std::io::Error::new(std::io::ErrorKind::Other, x),

--- a/quick-protobuf/src/reader.rs
+++ b/quick-protobuf/src/reader.rs
@@ -565,6 +565,7 @@ impl BytesReader {
 
     /// Gets the remaining length of bytes not read yet
     #[cfg_attr(std, inline(always))]
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.end - self.start
     }
@@ -642,6 +643,7 @@ pub struct Reader {
 impl Reader {
     /// Creates a new `Reader`
     #[cfg(feature = "std")]
+    #[allow(clippy::uninit_vec)]
     pub fn from_reader<R: Read>(mut r: R, capacity: usize) -> Result<Reader> {
         let mut buf = Vec::with_capacity(capacity);
         unsafe {


### PR DESCRIPTION
Fixes warnings thrown by clippy, or hides them where appropriate.