### PR TITLE
Added custom enum derive support

### DIFF
--- a/pb-rs/src/lib.rs
+++ b/pb-rs/src/lib.rs
@@ -56,6 +56,7 @@ pub struct ConfigBuilder {
     error_cycle: bool,
     headers: bool,
     dont_use_cow: bool,
+    custom_enum_derive: Vec<String>,
     custom_struct_derive: Vec<String>,
     custom_repr: Option<String>,
     owned: bool,
@@ -146,6 +147,12 @@ impl ConfigBuilder {
         self
     }
 
+    /// Add custom values to `#[derive(...)]` at the beginning of every enum
+    pub fn custom_enum_derive(mut self, val: Vec<String>) -> Self {
+        self.custom_enum_derive = val;
+        self
+    }
+
     /// Add custom values to `#[derive(...)]` at the beginning of every structure
     pub fn custom_struct_derive(mut self, val: Vec<String>) -> Self {
         self.custom_struct_derive = val;
@@ -226,6 +233,7 @@ impl ConfigBuilder {
                     error_cycle: self.error_cycle,
                     headers: self.headers,
                     dont_use_cow: self.dont_use_cow, //Change this to true to not use cow with ./generate.sh for v2 and v3 tests
+                    custom_enum_derive: self.custom_enum_derive.clone(),
                     custom_struct_derive: self.custom_struct_derive.clone(),
                     custom_repr: self.custom_repr.clone(),
                     custom_rpc_generator: Box::new(|_, _| Ok(())),

--- a/pb-rs/src/main.rs
+++ b/pb-rs/src/main.rs
@@ -63,6 +63,13 @@ fn run() -> Result<(), Error> {
                 .required(false)
                 .help("Do not add module comments and module attributes in generated file"),
         ).arg(
+            Arg::with_name("CUSTOM_ENUM_DERIVE")
+                .long("custom_enum_derive")
+                .short("E")
+                .required(false)
+                .takes_value(true)
+                .help("The comma separated values to add to #[derive(...)] for every enum"),
+        ).arg(
             Arg::with_name("CUSTOM_STRUCT_DERIVE")
                 .long("custom_struct_derive")
                 .short("C")
@@ -125,6 +132,12 @@ fn run() -> Result<(), Error> {
         .split(',')
         .map(|s| s.to_string())
         .collect();
+    let custom_enum_derive: Vec<String> = matches
+        .value_of("CUSTOM_ENUM_DERIVE")
+        .unwrap_or("")
+        .split(',')
+        .map(|s| s.to_string())
+        .collect();
 
     let compiler = ConfigBuilder::new(
         &in_files,
@@ -138,6 +151,7 @@ fn run() -> Result<(), Error> {
     .headers(!matches.is_present("NO_HEADERS"))
     .dont_use_cow(matches.is_present("DONT_USE_COW"))
     .custom_struct_derive(custom_struct_derive)
+    .custom_enum_derive(custom_enum_derive)
     .nostd(matches.is_present("NOSTD"))
     .hashbrown(matches.is_present("HASHBROWN"))
     .gen_info(matches.is_present("GEN_INFO"))

--- a/perftest/build.rs
+++ b/perftest/build.rs
@@ -54,6 +54,7 @@ fn main() {
         error_cycle: false,
         headers: false,
         dont_use_cow: false,
+        custom_enum_derive: vec![],
         custom_struct_derive: vec![],
         custom_repr: None,
         custom_rpc_generator: Box::new(|rpc, writer| generate_rpc_test(rpc, writer)),


### PR DESCRIPTION
This PR adds support for custom derives on enums (like the already supported custom derives on structs).

This is useful, for example, to add `serde::Deserialize` and `serde::Serialize` to both structs and enums to allow seamless support for multiple protocols in addition to protobuf

This is a proposed solution to https://github.com/tafia/quick-protobuf/issues/267